### PR TITLE
fixed warning with asset catalog when building with Xcode 5 / iOS 7 SDK

### DIFF
--- a/1Password.xcassets/extension-ipad.imageset/Contents.json
+++ b/1Password.xcassets/extension-ipad.imageset/Contents.json
@@ -1,9 +1,6 @@
 {
   "images" : [
     {
-      "idiom" : "universal"
-    },
-    {
       "idiom" : "universal",
       "scale" : "1x",
       "filename" : "extension-ipad.png"

--- a/1Password.xcassets/extension-iphone.imageset/Contents.json
+++ b/1Password.xcassets/extension-iphone.imageset/Contents.json
@@ -1,9 +1,6 @@
 {
   "images" : [
     {
-      "idiom" : "universal"
-    },
-    {
       "idiom" : "universal",
       "scale" : "1x"
     },


### PR DESCRIPTION
Fixed a build warning under Xcode 5 / iOS 7 SDK when compiling the 1Password.xcassets asset catalog.

The Xcode 5 warnings were:
The image set "extension-ipad" has an unassigned image.
The image set "extension-iphone" has an unassigned image.

I simply deleted the extra empty image.
