### PR TITLE
Added the ability to retrieve all submitted data after saving.

### DIFF
--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -59,6 +59,8 @@
 		}
 
 		__strong typeof(self) strongMe = miniMe;
+		strongMe.firstnameTextField.text = loginDict[AppExtensionFieldsKey][@"firstname"];
+		strongMe.lastnameTextField.text = loginDict[AppExtensionFieldsKey][@"lastname"];
 		strongMe.usernameTextField.text = loginDict[AppExtensionUsernameKey] ? : strongMe.usernameTextField.text;
 		strongMe.passwordTextField.text = loginDict[AppExtensionPasswordKey] ? : strongMe.passwordTextField.text;
 	}];


### PR DESCRIPTION
This pull request will resolve #23 .

If the the this party app sends data in `AppExtensionFieldsKey` and the user edits the data. The edited data will be sent back to the third party app.

_Note:_ This change requires a future version of 1Password Beta.
