### PR TITLE
Removed excluded UIActivityTypes.

### DIFF
--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -218,9 +218,6 @@ int const OPAppExtensionErrorCodeUnexpectedData = 6;
 
 	UIActivityViewController *controller = [[UIActivityViewController alloc] initWithActivityItems:@[ extensionItem ]  applicationActivities:nil];
 
-	// Excluding all available UIActivityTypes so that on the 1Password Extension is visible
-	controller.excludedActivityTypes = @[ UIActivityTypePostToFacebook, UIActivityTypePostToTwitter, UIActivityTypePostToWeibo, UIActivityTypeMessage, UIActivityTypeMail, UIActivityTypePrint, UIActivityTypeCopyToPasteboard, UIActivityTypeAssignToContact, UIActivityTypeSaveToCameraRoll, UIActivityTypeAddToReadingList, UIActivityTypePostToFlickr, UIActivityTypePostToVimeo, UIActivityTypePostToTencentWeibo, UIActivityTypeAirDrop ];
-
 	return controller;
 #else
     return nil;


### PR DESCRIPTION
Because in iOS 8 beta 5 only the 1Password Extension is visible.
