### PR TITLE
Fix Clang Warnings

### DIFF
--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -462,10 +462,10 @@ NSInteger const AppExtensionErrorCodeUnexpectedData = 6;
 		}
 
 		__strong __typeof__(self) strongMe = miniMe;
-		[strongMe processExtensionItem:returnedItems[0] completion:^(NSDictionary *loginDictionary, NSError *error) {
+		[strongMe processExtensionItem:returnedItems[0] completion:^(NSDictionary *loginDictionary, NSError *processExtensionItemError) {
 			if (!loginDictionary) {
 				if (completion) {
-					completion(NO, error);
+					completion(NO, processExtensionItemError);
 				}
 
 				return;
@@ -473,9 +473,9 @@ NSInteger const AppExtensionErrorCodeUnexpectedData = 6;
 			
 			__strong __typeof__(self) strongMe2 = miniMe;
 			NSString *fillScript = loginDictionary[AppExtensionWebViewPageFillScript];
-			[strongMe2 executeFillScript:fillScript inWebView:webView completion:^(BOOL success, NSError *error) {
+			[strongMe2 executeFillScript:fillScript inWebView:webView completion:^(BOOL success, NSError *executeFillScriptError) {
 				if (completion) {
-					completion(success, error);
+					completion(success, executeFillScriptError);
 				}
 			}];
 		}];


### PR DESCRIPTION
When integrating this I noticed that our project's clang configuration with `-Wsemicolon-before-method-body` and  `-Wshadow` was causing some warnings to show up inside the 1Password extension. This pull request resolves those warnings.

![screen shot 2014-10-03 at 8 46 30 am](https://cloud.githubusercontent.com/assets/522951/4508282/7680945c-4b14-11e4-907f-7d15736c4a71.png)
