### PR TITLE
Updated version number to 1.1

### DIFF
--- a/1PasswordExtension.podspec
+++ b/1PasswordExtension.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "1PasswordExtension"
-  s.version      = "1.0.9"
+  s.version      = "1.1"
   s.summary      = "With just a few lines of code, your app can add 1Password support."
 
   s.description  = <<-DESC

--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -8,7 +8,7 @@
 #import "OnePasswordExtension.h"
 
 // Version
-#define VERSION_NUMBER @(108)
+#define VERSION_NUMBER @(110)
 NSString *const AppExtensionVersionNumberKey = @"version_number";
 
 // Available App Extension Actions


### PR DESCRIPTION
Proposed release notes for version 1.1:
- Updated the README
- Improved error messages and the code in general.
- Replaced all occurrences of `typeof` with `__typeof__` which fixes build errors for some users.
- Fix clang warning concerning some local variables.
- Fixed crash that could occur when the 1Password extension is invoked before the web view is fully loaded.
