### PR TITLE
Fixing missing parameter type

### DIFF
--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -439,7 +439,7 @@ NSInteger const AppExtensionErrorCodeFailedToObtainURLStringFromWebView = 7;
 	}];
 }
 
-- (void)findLoginIn1PasswordWithURLString:URLString collectedPageDetails:(NSString *)collectedPageDetails forWebViewController:(UIViewController *)forViewController sender:(id)sender withWebView:(id)webView completion:(void (^)(BOOL success, NSError *error))completion {
+- (void)findLoginIn1PasswordWithURLString:(NSString *)URLString collectedPageDetails:(NSString *)collectedPageDetails forWebViewController:(UIViewController *)forViewController sender:(id)sender withWebView:(id)webView completion:(void (^)(BOOL success, NSError *error))completion {
 	if ([URLString length] == 0) {
 		NSError *URLStringError = [OnePasswordExtension failedToObtainURLStringFromWebViewError];
 		NSLog(@"Failed to findLoginIn1PasswordWithURLString: %@", URLStringError);


### PR DESCRIPTION
Hey all,

I found a missing parameter's type. It was generating a warning in xcode (multiple length methods) 
Greetings and have a nice day!
Patryk
