### PR TITLE
Validate that the new password and the old password are not the same when changing the password in ACME

### DIFF
--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -33,19 +33,19 @@
 }
 
 - (IBAction)changePasswordIn1Password:(id)sender {
-	NSString *changedPassword = self.freshPasswordTextField.text ? : @"";
+	NSString *newPassword = self.freshPasswordTextField.text ? : @"";
+	NSString *oldPassword = self.oldPasswordTextField.text ? : @"";
+	NSString *confirmationPassword = self.confirmPasswordTextField.text ? : @"";
+
+	// Validate that the new password and the old password are not the same.
+	if ([oldPassword isEqualToString:newPassword]) {
+		[self showChangePasswordFailedAlertWithMessage:@"The old and the new password must not be the same"];
+		return;
+	}
 
 	// Validate that the new and confirmation passwords match.
-	if (changedPassword.length > 0 && ![changedPassword isEqualToString:self.confirmPasswordTextField.text]) {
-		UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Change Password Error" message:@"The new and the confirmation passwords must match" preferredStyle:UIAlertControllerStyleAlert];
-		UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
-			self.freshPasswordTextField.text = @"";
-			self.confirmPasswordTextField.text = @"";
-			[self.freshPasswordTextField becomeFirstResponder];
-		}];
-
-		[alert addAction:dismissAction];
-		[self presentViewController:alert animated:YES completion:nil];
+	if (NO == [newPassword isEqualToString:confirmationPassword]) {
+		[self showChangePasswordFailedAlertWithMessage:@"The new passwords and the confirmation password must match"];
 		return;
 	}
 
@@ -54,8 +54,8 @@
 	NSDictionary *loginDetails = @{
 									  AppExtensionTitleKey: @"ACME",
 									  AppExtensionUsernameKey: username, // 1Password will prompt the user to create a new item if no matching logins are found with this username.
-									  AppExtensionPasswordKey: changedPassword,
-									  AppExtensionOldPasswordKey: self.oldPasswordTextField.text ? : @"",
+									  AppExtensionPasswordKey: newPassword,
+									  AppExtensionOldPasswordKey: oldPassword,
 									  AppExtensionNotesKey: @"Saved with the ACME app",
 									};
 
@@ -80,6 +80,20 @@
 		strongMe.freshPasswordTextField.text = loginDict[AppExtensionPasswordKey];
 		strongMe.confirmPasswordTextField.text = loginDict[AppExtensionPasswordKey];
 	}];
+}
+
+#pragma mark - Convenience methods
+
+- (void)showChangePasswordFailedAlertWithMessage:(NSString *)message {
+	UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Change Password Error" message:message preferredStyle:UIAlertControllerStyleAlert];
+	UIAlertAction *dismissAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
+		self.freshPasswordTextField.text = @"";
+		self.confirmPasswordTextField.text = @"";
+		[self.freshPasswordTextField becomeFirstResponder];
+	}];
+
+	[alert addAction:dismissAction];
+	[self presentViewController:alert animated:YES completion:nil];
 }
 
 @end


### PR DESCRIPTION
This change will not affect the way the App Extension API currently works.

It is just a change in ACME app to showcase the importace of password validation from the 3rd party application prior to calling the 1Password Extension.
