### PR TITLE
Added format string to prevent unused variadic argument in NSAssert.

### DIFF
--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -53,8 +53,8 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 }
 
 - (void)findLoginForURLString:(NSString *)URLString forViewController:(UIViewController *)viewController sender:(id)sender completion:(void (^)(NSDictionary *loginDictionary, NSError *error))completion {
-	NSAssert(URLString != nil, @"URLString must not be nil");
-	NSAssert(viewController != nil, @"viewController must not be nil");
+	NSAssert(URLString != nil, @"%@", @"URLString must not be nil");
+	NSAssert(viewController != nil, @"%@", @"viewController must not be nil");
 
 	if (![self isSystemAppExtensionAPIAvailable]) {
 		NSLog(@"Failed to findLoginForURLString, system API is not available");
@@ -102,9 +102,9 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 }
 
 - (void)storeLoginForURLString:(NSString *)URLString loginDetails:(NSDictionary *)loginDetailsDict passwordGenerationOptions:(NSDictionary *)passwordGenerationOptions forViewController:(UIViewController *)viewController sender:(id)sender completion:(void (^)(NSDictionary *, NSError *))completion {
-	NSAssert(URLString != nil, @"URLString must not be nil");
-	NSAssert(loginDetailsDict != nil, @"loginDetailsDict must not be nil");
-	NSAssert(viewController != nil, @"viewController must not be nil");
+	NSAssert(URLString != nil, @"%@", @"URLString must not be nil");
+	NSAssert(loginDetailsDict != nil, @"%@", @"loginDetailsDict must not be nil");
+	NSAssert(viewController != nil, @"%@", @"viewController must not be nil");
 
 	if (![self isSystemAppExtensionAPIAvailable]) {
 		NSLog(@"Failed to storeLoginForURLString, system API is not available");
@@ -159,8 +159,8 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 }
 
 - (void)changePasswordForLoginForURLString:(NSString *)URLString loginDetails:(NSDictionary *)loginDetailsDict passwordGenerationOptions:(NSDictionary *)passwordGenerationOptions forViewController:(UIViewController *)viewController sender:(id)sender completion:(void (^)(NSDictionary *loginDict, NSError *error))completion {
-	NSAssert(URLString != nil, @"URLString must not be nil");
-	NSAssert(viewController != nil, @"viewController must not be nil");
+	NSAssert(URLString != nil, @"%@", @"URLString must not be nil");
+	NSAssert(viewController != nil, @"%@", @"viewController must not be nil");
 
 	if (![self isSystemAppExtensionAPIAvailable]) {
 		NSLog(@"Failed to changePasswordForLoginWithUsername, system API is not available");
@@ -214,8 +214,8 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 }
 
 - (void)fillLoginIntoWebView:(id)webView forViewController:(UIViewController *)viewController sender:(id)sender completion:(void (^)(BOOL success, NSError *error))completion {
-	NSAssert(webView != nil, @"webView must not be nil");
-	NSAssert(viewController != nil, @"viewController must not be nil");
+	NSAssert(webView != nil, @"%@", @"webView must not be nil");
+	NSAssert(viewController != nil, @"%@", @"viewController must not be nil");
 
 #ifdef __IPHONE_8_0
 	if ([webView isKindOfClass:[UIWebView class]]) {


### PR DESCRIPTION
Not providing at least one argument to a variadic argument in a macro
with other arguments is a violation of ISO C ("there shall be more
arguments in the invocation than there are parameters in the macro
definition (excluding the ...)").

This previously produced a warning quiesced by the switch:
-Wno-gnu-zero-variadic-macro-arguments