### PR TITLE
Replaced the email for beta access alert with a link to get 1Password from the App Store when 1Password is not installed.

### DIFF
--- a/Demos/App Demo for iOS/App Demo for iOS/AppDelegate.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/AppDelegate.m
@@ -9,9 +9,7 @@
 #import "AppDelegate.h"
 #import "OnePasswordExtension.h"
 
-#import <MessageUI/MFMailComposeViewController.h>
-
-@interface AppDelegate () <UIAlertViewDelegate, MFMailComposeViewControllerDelegate>
+@interface AppDelegate () <UIAlertViewDelegate>
 
 @end
 
@@ -20,7 +18,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 	if (![[OnePasswordExtension sharedExtension] isAppExtensionAvailable]) {
-		UIAlertView * alertView = [[UIAlertView alloc] initWithTitle:@"1Password Beta is not installed" message:@"Email support+appex@agilebits.com for beta access" delegate:self cancelButtonTitle:@"Cancel" otherButtonTitles:@"Email", nil];
+		UIAlertView * alertView = [[UIAlertView alloc] initWithTitle:@"1Password is not installed" message:@"Get 1Password from the App Store" delegate:self cancelButtonTitle:@"Cancel" otherButtonTitles:@"Get 1Password", nil];
 		[alertView show];
 	}
 
@@ -53,21 +51,8 @@
 
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
 	if (buttonIndex == alertView.firstOtherButtonIndex) {
-		MFMailComposeViewController* composeViewController = [[MFMailComposeViewController alloc] init];
-		composeViewController.mailComposeDelegate = self;
-		[composeViewController setToRecipients:@[ @"support+appex@agilebits.com" ]];
-		[composeViewController setSubject:@"App Extension"];
-
-		UIWindow *window = [UIApplication sharedApplication].windows.firstObject;
-		UIViewController *rootViewController = window.rootViewController;
-		[rootViewController presentViewController:composeViewController animated:YES completion:nil];
+		[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://itunes.apple.com/ca/app/1password-password-manager/id568903335?mt=8"]];
 	}
-}
-
-#pragma mark - MFMailComposeViewControllerDelegate
-
-- (void)mailComposeController:(MFMailComposeViewController*)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError*)error {
-	[controller dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end

--- a/Demos/WebView Demo for iOS/WebView Demo for iOS/AppDelegate.m
+++ b/Demos/WebView Demo for iOS/WebView Demo for iOS/AppDelegate.m
@@ -9,9 +9,7 @@
 #import "AppDelegate.h"
 #import "OnePasswordExtension.h"
 
-#import <MessageUI/MFMailComposeViewController.h>
-
-@interface AppDelegate () <UIAlertViewDelegate, MFMailComposeViewControllerDelegate>
+@interface AppDelegate () <UIAlertViewDelegate>
 
 @end
 
@@ -20,7 +18,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 	if (![[OnePasswordExtension sharedExtension] isAppExtensionAvailable]) {
-		UIAlertView * alertView = [[UIAlertView alloc] initWithTitle:@"1Password Beta is not installed" message:@"Email support+appex@agilebits.com for beta access" delegate:self cancelButtonTitle:@"Cancel" otherButtonTitles:@"Email", nil];
+		UIAlertView * alertView = [[UIAlertView alloc] initWithTitle:@"1Password is not installed" message:@"Get 1Password from the App Store" delegate:self cancelButtonTitle:@"Cancel" otherButtonTitles:@"Get 1Password", nil];
 		[alertView show];
 	}
 
@@ -53,21 +51,8 @@
 
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
 	if (buttonIndex == alertView.firstOtherButtonIndex) {
-		MFMailComposeViewController* composeViewController = [[MFMailComposeViewController alloc] init];
-		composeViewController.mailComposeDelegate = self;
-		[composeViewController setToRecipients:@[ @"support+appex@agilebits.com" ]];
-		[composeViewController setSubject:@"App Extension"];
-
-		UIWindow *window = [UIApplication sharedApplication].windows.firstObject;
-		UIViewController *rootViewController = window.rootViewController;
-		[rootViewController presentViewController:composeViewController animated:YES completion:nil];
+		[[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://itunes.apple.com/ca/app/1password-password-manager/id568903335?mt=8"]];
 	}
-}
-
-#pragma mark - MFMailComposeViewControllerDelegate
-
-- (void)mailComposeController:(MFMailComposeViewController*)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError*)error {
-	[controller dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end


### PR DESCRIPTION
1Password beta is no longer required to integrate with the 1Password App Extension API. Developers simply need to download 1Password from the App Store to test their integration.

**BEFORE:**

![](https://www.evernote.com/shard/s340/sh/d122df43-68f1-419c-8b91-586a01dc7320/4d8fdde59bae153d4af299013d696ba8/deep/0/Screenshot-2014-12-29,-7-32-PM.png)

**AFTER:**

![](https://www.evernote.com/shard/s340/sh/1d354fb2-7b09-499b-94df-a40dda81ce6e/dcac44596f0a71dbf3c01ddefcd3e80e/deep/0/Screenshot-2014-12-29,-7-33-PM.png)