### PR TITLE
Add support for Carthage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ DerivedData
 .idea/
 
 *.rej
+
+# Carthage
+Carthage/Build

--- a/Demos/1Password Extension Demos.xcworkspace/contents.xcworkspacedata
+++ b/Demos/1Password Extension Demos.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:../OnePasswordExtension.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:App Demo for iOS/App Demo for iOS.xcodeproj">
    </FileRef>
    <FileRef

--- a/Demos/App Demo for iOS/App Demo for iOS.xcodeproj/project.pbxproj
+++ b/Demos/App Demo for iOS/App Demo for iOS.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9C3F4DC81A59B1FF004B3ECE /* OnePasswordExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C3F4DC71A59B1F9004B3ECE /* OnePasswordExtension.framework */; };
+		9C3F4DC91A59B1FF004B3ECE /* OnePasswordExtension.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9C3F4DC71A59B1F9004B3ECE /* OnePasswordExtension.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C015EF6919992AC70044A194 /* ChangePasswordViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C015EF6819992AC70044A194 /* ChangePasswordViewController.m */; };
 		C015EF6C19992DF70044A194 /* LoginInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = C015EF6B19992DF70044A194 /* LoginInformation.m */; };
-		C053E05B19945A45002E80C5 /* 1Password.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C053E05A19945A45002E80C5 /* 1Password.xcassets */; };
-		C0F0C18519889441000B261F /* OnePasswordExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = C0F0C18419889441000B261F /* OnePasswordExtension.m */; };
 		C0F0C18819889456000B261F /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C0F0C18719889456000B261F /* AppDelegate.m */; };
 		C0F0C19019889467000B261F /* LoginViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C0F0C18A19889467000B261F /* LoginViewController.m */; };
 		C0F0C19119889467000B261F /* RegisterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C0F0C18C19889467000B261F /* RegisterViewController.m */; };
@@ -20,14 +20,43 @@
 		C0F0C19D19889519000B261F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C0F0C19619889498000B261F /* Main.storyboard */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		9C3F4DC61A59B1F9004B3ECE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9C3F4DC21A59B1F9004B3ECE /* OnePasswordExtension.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9C3F4D8C1A59ACDC004B3ECE;
+			remoteInfo = OnePasswordExtension;
+		};
+		9C3F4DCA1A59B1FF004B3ECE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9C3F4DC21A59B1F9004B3ECE /* OnePasswordExtension.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 9C3F4D8B1A59ACDC004B3ECE;
+			remoteInfo = OnePasswordExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		9C3F4DC11A59B14D004B3ECE /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				9C3F4DC91A59B1FF004B3ECE /* OnePasswordExtension.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		9C3F4DC21A59B1F9004B3ECE /* OnePasswordExtension.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = OnePasswordExtension.xcodeproj; path = ../OnePasswordExtension.xcodeproj; sourceTree = "<group>"; };
 		C015EF6719992AC70044A194 /* ChangePasswordViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ChangePasswordViewController.h; path = "App Demo for iOS/App Demo for iOS/ChangePasswordViewController.h"; sourceTree = "<group>"; };
 		C015EF6819992AC70044A194 /* ChangePasswordViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ChangePasswordViewController.m; path = "App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m"; sourceTree = "<group>"; };
 		C015EF6A19992DF70044A194 /* LoginInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LoginInformation.h; path = "App Demo for iOS/App Demo for iOS/LoginInformation.h"; sourceTree = "<group>"; };
 		C015EF6B19992DF70044A194 /* LoginInformation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LoginInformation.m; path = "App Demo for iOS/App Demo for iOS/LoginInformation.m"; sourceTree = "<group>"; };
-		C053E05A19945A45002E80C5 /* 1Password.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = 1Password.xcassets; path = ../1Password.xcassets; sourceTree = "<group>"; };
-		C0F0C18319889441000B261F /* OnePasswordExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OnePasswordExtension.h; path = ../../OnePasswordExtension.h; sourceTree = SOURCE_ROOT; };
-		C0F0C18419889441000B261F /* OnePasswordExtension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OnePasswordExtension.m; path = ../../OnePasswordExtension.m; sourceTree = SOURCE_ROOT; };
 		C0F0C18619889456000B261F /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = "App Demo for iOS/App Demo for iOS/AppDelegate.h"; sourceTree = "<group>"; };
 		C0F0C18719889456000B261F /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = "App Demo for iOS/App Demo for iOS/AppDelegate.m"; sourceTree = "<group>"; };
 		C0F0C18919889467000B261F /* LoginViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LoginViewController.h; path = "App Demo for iOS/App Demo for iOS/LoginViewController.h"; sourceTree = "<group>"; };
@@ -48,12 +77,21 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9C3F4DC81A59B1FF004B3ECE /* OnePasswordExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9C3F4DC31A59B1F9004B3ECE /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9C3F4DC71A59B1F9004B3ECE /* OnePasswordExtension.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		C0FA528E1974821100570166 = {
 			isa = PBXGroup;
 			children = (
@@ -73,8 +111,6 @@
 		C0FA52991974821100570166 /* App Demo for iOS */ = {
 			isa = PBXGroup;
 			children = (
-				C0F0C18319889441000B261F /* OnePasswordExtension.h */,
-				C0F0C18419889441000B261F /* OnePasswordExtension.m */,
 				C0F0C18619889456000B261F /* AppDelegate.h */,
 				C0F0C18719889456000B261F /* AppDelegate.m */,
 				C0F0C18919889467000B261F /* LoginViewController.h */,
@@ -89,7 +125,6 @@
 				C015EF6B19992DF70044A194 /* LoginInformation.m */,
 				C0F0C19619889498000B261F /* Main.storyboard */,
 				C0F0C19419889479000B261F /* Images.xcassets */,
-				C053E05A19945A45002E80C5 /* 1Password.xcassets */,
 				C0FA529A1974821100570166 /* Supporting Files */,
 			);
 			name = "App Demo for iOS";
@@ -99,6 +134,7 @@
 		C0FA529A1974821100570166 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				9C3F4DC21A59B1F9004B3ECE /* OnePasswordExtension.xcodeproj */,
 				C0F0C199198894ED000B261F /* Info.plist */,
 				C0F0C19B198894F8000B261F /* main.m */,
 			);
@@ -115,10 +151,12 @@
 				C0FA52931974821100570166 /* Sources */,
 				C0FA52941974821100570166 /* Frameworks */,
 				C0FA52951974821100570166 /* Resources */,
+				9C3F4DC11A59B14D004B3ECE /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				9C3F4DCB1A59B1FF004B3ECE /* PBXTargetDependency */,
 			);
 			name = ACME;
 			productName = "1Password Extension Demo";
@@ -150,12 +188,28 @@
 			mainGroup = C0FA528E1974821100570166;
 			productRefGroup = C0FA52981974821100570166 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 9C3F4DC31A59B1F9004B3ECE /* Products */;
+					ProjectRef = 9C3F4DC21A59B1F9004B3ECE /* OnePasswordExtension.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				C0FA52961974821100570166 /* ACME */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		9C3F4DC71A59B1F9004B3ECE /* OnePasswordExtension.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = OnePasswordExtension.framework;
+			remoteRef = 9C3F4DC61A59B1F9004B3ECE /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		C0FA52951974821100570166 /* Resources */ = {
@@ -164,7 +218,6 @@
 			files = (
 				C0F0C19519889479000B261F /* Images.xcassets in Resources */,
 				C0F0C19D19889519000B261F /* Main.storyboard in Resources */,
-				C053E05B19945A45002E80C5 /* 1Password.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -178,7 +231,6 @@
 				C0F0C19019889467000B261F /* LoginViewController.m in Sources */,
 				C0F0C19219889467000B261F /* ThankYouViewController.m in Sources */,
 				C0F0C19119889467000B261F /* RegisterViewController.m in Sources */,
-				C0F0C18519889441000B261F /* OnePasswordExtension.m in Sources */,
 				C015EF6C19992DF70044A194 /* LoginInformation.m in Sources */,
 				C0F0C19C198894F8000B261F /* main.m in Sources */,
 				C015EF6919992AC70044A194 /* ChangePasswordViewController.m in Sources */,
@@ -187,6 +239,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		9C3F4DCB1A59B1FF004B3ECE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = OnePasswordExtension;
+			targetProxy = 9C3F4DCA1A59B1FF004B3ECE /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C0F0C19619889498000B261F /* Main.storyboard */ = {

--- a/Demos/App Demo for iOS/App Demo for iOS/AppDelegate.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/AppDelegate.m
@@ -7,7 +7,7 @@
 //
 
 #import "AppDelegate.h"
-#import "OnePasswordExtension.h"
+#import <OnePasswordExtension/OnePasswordExtension.h>
 
 #import <MessageUI/MFMailComposeViewController.h>
 

--- a/Demos/App Demo for iOS/App Demo for iOS/Base.lproj/Main.storyboard
+++ b/Demos/App Demo for iOS/App Demo for iOS/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6205" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6198"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
     <scenes>
         <!--Login View Controller-->
@@ -92,7 +92,7 @@
                                 </constraints>
                                 <inset key="contentEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
                                 <inset key="imageEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
-                                <state key="normal" image="onepassword-button">
+                                <state key="normal">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
@@ -197,7 +197,7 @@
                                     <constraint firstAttribute="height" constant="44" id="Mys-Ca-bIm"/>
                                 </constraints>
                                 <inset key="contentEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
-                                <state key="normal" image="onepassword-button">
+                                <state key="normal">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
@@ -362,7 +362,7 @@
                                 </constraints>
                                 <inset key="contentEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
                                 <inset key="imageEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
-                                <state key="normal" image="onepassword-button">
+                                <state key="normal">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
@@ -410,9 +410,6 @@
             </objects>
         </scene>
     </scenes>
-    <resources>
-        <image name="onepassword-button" width="27" height="27"/>
-    </resources>
     <inferredMetricsTieBreakers>
         <segue reference="60D-yv-qSt"/>
     </inferredMetricsTieBreakers>

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -25,6 +25,10 @@
 	[super viewDidLoad];
 	[[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:UIStatusBarAnimationNone];
 	[self.view setBackgroundColor:[[UIColor alloc] initWithPatternImage:[UIImage imageNamed:@"login-background.png"]]];
+
+	NSBundle *onePasswordExtensionBundle = [NSBundle bundleForClass:[OnePasswordExtension class]];
+	UIImage *onePasswordButtonImage = [UIImage imageNamed:@"onepassword-button" inBundle:onePasswordExtensionBundle compatibleWithTraitCollection:self.traitCollection];
+	[self.onepasswordSigninButton setImage:onePasswordButtonImage forState:UIControlStateNormal];
 	[self.onepasswordSigninButton setHidden:![[OnePasswordExtension sharedExtension] isAppExtensionAvailable]];
 }
 

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -7,7 +7,7 @@
 //
 
 #import "ChangePasswordViewController.h"
-#import "OnePasswordExtension.h"
+#import <OnePasswordExtension/OnePasswordExtension.h>
 #import "LoginInformation.h"
 
 @interface ChangePasswordViewController ()

--- a/Demos/App Demo for iOS/App Demo for iOS/LoginViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/LoginViewController.m
@@ -23,6 +23,10 @@
 - (void)viewDidLoad {
 	[[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:UIStatusBarAnimationNone];
 	[self.view setBackgroundColor:[[UIColor alloc] initWithPatternImage:[UIImage imageNamed:@"login-background.png"]]];
+
+	NSBundle *onePasswordExtensionBundle = [NSBundle bundleForClass:[OnePasswordExtension class]];
+	UIImage *onePasswordButtonImage = [UIImage imageNamed:@"onepassword-button" inBundle:onePasswordExtensionBundle compatibleWithTraitCollection:self.traitCollection];
+	[self.onepasswordSigninButton setImage:onePasswordButtonImage forState:UIControlStateNormal];
 	[self.onepasswordSigninButton setHidden:![[OnePasswordExtension sharedExtension] isAppExtensionAvailable]];
 }
 

--- a/Demos/App Demo for iOS/App Demo for iOS/LoginViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/LoginViewController.m
@@ -7,7 +7,7 @@
 //
 
 #import "LoginViewController.h"
-#import "OnePasswordExtension.h"
+#import <OnePasswordExtension/OnePasswordExtension.h>
 #import "LoginInformation.h"
 
 @interface LoginViewController () <UITextFieldDelegate>

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -7,7 +7,7 @@
 //
 
 #import "RegisterViewController.h"
-#import "OnePasswordExtension.h"
+#import <OnePasswordExtension/OnePasswordExtension.h>
 #import "LoginInformation.h"
 
 @interface RegisterViewController () <UITextFieldDelegate>

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -25,6 +25,10 @@
 
 - (void)viewDidLoad {
 	[self.view setBackgroundColor:[[UIColor alloc] initWithPatternImage:[UIImage imageNamed:@"register-background.png"]]];
+
+	NSBundle *onePasswordExtensionBundle = [NSBundle bundleForClass:[OnePasswordExtension class]];
+	UIImage *onePasswordButtonImage = [UIImage imageNamed:@"onepassword-button" inBundle:onePasswordExtensionBundle compatibleWithTraitCollection:self.traitCollection];
+	[self.onepasswordSignupButton setImage:onePasswordButtonImage forState:UIControlStateNormal];
 	[self.onepasswordSignupButton setHidden:![[OnePasswordExtension sharedExtension] isAppExtensionAvailable]];
 }
 

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.agilebits.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/OnePasswordExtension.xcodeproj/project.pbxproj
+++ b/OnePasswordExtension.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		9C3F4DB11A59AE7D004B3ECE /* OnePasswordExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C3F4DAF1A59AE7D004B3ECE /* OnePasswordExtension.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9C3F4DB21A59AE7D004B3ECE /* OnePasswordExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C3F4DB01A59AE7D004B3ECE /* OnePasswordExtension.m */; };
 		9C3F4DB41A59AEB3004B3ECE /* 1Password.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F4DB31A59AEB3004B3ECE /* 1Password.xcassets */; };
-		9C3F4DB61A59AECD004B3ECE /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C3F4DB51A59AECD004B3ECE /* WebKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,7 +26,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9C3F4DB61A59AECD004B3ECE /* WebKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OnePasswordExtension.xcodeproj/project.pbxproj
+++ b/OnePasswordExtension.xcodeproj/project.pbxproj
@@ -1,0 +1,297 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9C3F4DB11A59AE7D004B3ECE /* OnePasswordExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C3F4DAF1A59AE7D004B3ECE /* OnePasswordExtension.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9C3F4DB21A59AE7D004B3ECE /* OnePasswordExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C3F4DB01A59AE7D004B3ECE /* OnePasswordExtension.m */; };
+		9C3F4DB41A59AEB3004B3ECE /* 1Password.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9C3F4DB31A59AEB3004B3ECE /* 1Password.xcassets */; };
+		9C3F4DB61A59AECD004B3ECE /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C3F4DB51A59AECD004B3ECE /* WebKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		9C3F4D8C1A59ACDC004B3ECE /* OnePasswordExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OnePasswordExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9C3F4DAD1A59AE76004B3ECE /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9C3F4DAF1A59AE7D004B3ECE /* OnePasswordExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OnePasswordExtension.h; sourceTree = "<group>"; };
+		9C3F4DB01A59AE7D004B3ECE /* OnePasswordExtension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OnePasswordExtension.m; sourceTree = "<group>"; };
+		9C3F4DB31A59AEB3004B3ECE /* 1Password.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = 1Password.xcassets; sourceTree = "<group>"; };
+		9C3F4DB51A59AECD004B3ECE /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9C3F4D881A59ACDC004B3ECE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C3F4DB61A59AECD004B3ECE /* WebKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9C3F4D821A59ACDC004B3ECE = {
+			isa = PBXGroup;
+			children = (
+				9C3F4DAB1A59AE4E004B3ECE /* OnePasswordExtension */,
+				9C3F4D8D1A59ACDC004B3ECE /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9C3F4D8D1A59ACDC004B3ECE /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9C3F4D8C1A59ACDC004B3ECE /* OnePasswordExtension.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9C3F4DAB1A59AE4E004B3ECE /* OnePasswordExtension */ = {
+			isa = PBXGroup;
+			children = (
+				9C3F4DAF1A59AE7D004B3ECE /* OnePasswordExtension.h */,
+				9C3F4DB01A59AE7D004B3ECE /* OnePasswordExtension.m */,
+				9C3F4DB31A59AEB3004B3ECE /* 1Password.xcassets */,
+				9C3F4DAC1A59AE64004B3ECE /* Supporting Files */,
+			);
+			name = OnePasswordExtension;
+			sourceTree = "<group>";
+		};
+		9C3F4DAC1A59AE64004B3ECE /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				9C3F4DB51A59AECD004B3ECE /* WebKit.framework */,
+				9C3F4DAD1A59AE76004B3ECE /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		9C3F4D891A59ACDC004B3ECE /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C3F4DB11A59AE7D004B3ECE /* OnePasswordExtension.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		9C3F4D8B1A59ACDC004B3ECE /* OnePasswordExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9C3F4DA21A59ACDC004B3ECE /* Build configuration list for PBXNativeTarget "OnePasswordExtension" */;
+			buildPhases = (
+				9C3F4D871A59ACDC004B3ECE /* Sources */,
+				9C3F4D881A59ACDC004B3ECE /* Frameworks */,
+				9C3F4D891A59ACDC004B3ECE /* Headers */,
+				9C3F4D8A1A59ACDC004B3ECE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OnePasswordExtension;
+			productName = OnePasswordExtension;
+			productReference = 9C3F4D8C1A59ACDC004B3ECE /* OnePasswordExtension.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9C3F4D831A59ACDC004B3ECE /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0610;
+				ORGANIZATIONNAME = "AgileBits Inc.";
+				TargetAttributes = {
+					9C3F4D8B1A59ACDC004B3ECE = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 9C3F4D861A59ACDC004B3ECE /* Build configuration list for PBXProject "OnePasswordExtension" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 9C3F4D821A59ACDC004B3ECE;
+			productRefGroup = 9C3F4D8D1A59ACDC004B3ECE /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9C3F4D8B1A59ACDC004B3ECE /* OnePasswordExtension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		9C3F4D8A1A59ACDC004B3ECE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C3F4DB41A59AEB3004B3ECE /* 1Password.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9C3F4D871A59ACDC004B3ECE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C3F4DB21A59AE7D004B3ECE /* OnePasswordExtension.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		9C3F4DA01A59ACDC004B3ECE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		9C3F4DA11A59ACDC004B3ECE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		9C3F4DA31A59ACDC004B3ECE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = OnePasswordExtension;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		9C3F4DA41A59ACDC004B3ECE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = OnePasswordExtension;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9C3F4D861A59ACDC004B3ECE /* Build configuration list for PBXProject "OnePasswordExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9C3F4DA01A59ACDC004B3ECE /* Debug */,
+				9C3F4DA11A59ACDC004B3ECE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9C3F4DA21A59ACDC004B3ECE /* Build configuration list for PBXNativeTarget "OnePasswordExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9C3F4DA31A59ACDC004B3ECE /* Debug */,
+				9C3F4DA41A59ACDC004B3ECE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 9C3F4D831A59ACDC004B3ECE /* Project object */;
+}

--- a/OnePasswordExtension.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/OnePasswordExtension.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:OnePasswordExtension.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/OnePasswordExtension.xcodeproj/xcshareddata/xcschemes/OnePasswordExtension.xcscheme
+++ b/OnePasswordExtension.xcodeproj/xcshareddata/xcschemes/OnePasswordExtension.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0610"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9C3F4D8B1A59ACDC004B3ECE"
+               BuildableName = "OnePasswordExtension.framework"
+               BlueprintName = "OnePasswordExtension"
+               ReferencedContainer = "container:OnePasswordExtension.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9C3F4D8B1A59ACDC004B3ECE"
+            BuildableName = "OnePasswordExtension.framework"
+            BlueprintName = "OnePasswordExtension"
+            ReferencedContainer = "container:OnePasswordExtension.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9C3F4D8B1A59ACDC004B3ECE"
+            BuildableName = "OnePasswordExtension.framework"
+            BlueprintName = "OnePasswordExtension"
+            ReferencedContainer = "container:OnePasswordExtension.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
[Carthage](https://github.com/Carthage/Carthage) needs an Xcode project as well as a shared Xcode scheme. So this PR aims to add that and as such make the project be includable via Carthage :smiley: 

- Compatibility with manually including the source files and assets is maintained.
- Changed the “App Demo for iOS” app to use the framework instead of manually including the source files.
  - This highlights that we perhaps 

As a side note: the extension and framework seem to work from Swift:
```swift
import OnePasswordExtension

func woop() {
    OnePasswordExtension.sharedExtension()
}
```
:point_up: compiles and links just fine :smile: 

### Known issues
- The code can be used in an app with the deployment target of iOS 7.0 but Carthage requires a dynamic framework which in turns requires iOS 8.0. As such the output of the _OnePasswordExtension_ target requires a deployment version of ≥8.0.
- As image assets (`onepassword-*.png`) are now bundled with the framework one must extract them from that bundle.
  - See the code below at the star (*) for how.
  - I’ve updated the example app to do this.
  - I don’t know if it’s possible, and if so how, to use an image from a separate bundle in Storyboards. The image shows up in Xcode but it can’t be loaded at runtime :pensive:

----
*) Extracting the images is a two-liner:
```objc
// In your UIViewController subclass’s
- (void)viewDidLoad {    
    // [...]
    NSBundle *onePasswordExtensionBundle = [NSBundle bundleForClass:[OnePasswordExtension class]];
    UIImage *onePasswordButtonImage = [UIImage imageNamed:@"onepassword-button" inBundle:onePasswordExtensionBundle compatibleWithTraitCollection:self.traitCollection];
    [self.onePasswordButton setImage:onePasswordButtonImage for
}
```
or in Swift
```swift
override func viewDidLoad() {
    // [...]
    let onePasswordExtensionBundle = NSBundle(forClass: OnePasswordExtension.self)
    let onePasswordButtonImage = UIImage(named: "onepassword-button", inBundle: onePasswordExtensionBundle, compatibleWithTraitCollection: self.traitCollection)
    self.onePasswordButton.setImage(onePasswordButtonImage, forState: .Normal)
}
```

Given this I’m considering if it would be worth to add a small category on `UIImage` which would return the image. I’m thinking something along the lines of:
```objc
typedef NS_ENUM(NSInteger, OnePasswordExtensionImageType) {
    OnePasswordExtensionImageTypeButton,
    OnePasswordExtensionImageTypeExtension,
    OnePasswordExtensionImageTypeNavigationBar,
    OnePasswordExtensionImageTypeToolbar
};

@implementation UIImage (OnePasswordExtension)
+ (instancetype)onePasswordExtensionImageOfType:(OnePasswordExtensionImageType)imageType compatibleWithTraitCollection:(UITraitCollection *)traitCollection {
    NSString *imageName = [self nameForonePasswordExtensionImageOfType:imageType];
    NSBundle *bundle = [NSBundle bundleForClass:[OnePasswordExtension class]];
    UIImage *image = [UIImage imageNamed:imageName inBundle:bundle compatibleWithTraitCollection:traitCollection];
    return image;
}
@end
```
If this sound interesting to you I’ll submit a new PR if/when this PR has been merged.