### PR TITLE
Fixed validation problem in ACME where the old password need to be typed when changing the password.

### DIFF
--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -38,7 +38,7 @@
 	NSString *confirmationPassword = self.confirmPasswordTextField.text ? : @"";
 
 	// Validate that the new password and the old password are not the same.
-	if ([oldPassword isEqualToString:newPassword]) {
+	if (oldPassword.length > 0 && [oldPassword isEqualToString:newPassword]) {
 		[self showChangePasswordFailedAlertWithMessage:@"The old and the new password must not be the same"];
 		return;
 	}


### PR DESCRIPTION
**Steps to reproduce:**

1. Go the the Change Password view
2. Do not enter any values for the old, new and confirmation passwords.

**Expected behaviour:**
The share sheet should be available because they old password may be too long to type. It will be returned by 1Password after the user changes it in the detail view.

![](https://www.evernote.com/shard/s340/sh/30389962-a189-4048-8b8f-068d85cf863f/90c24f29ac077dba373d03efb8e97645/deep/0/iOS-Simulator---iPhone-6---iPhone-6---iOS-8.1-(12B411).png)

**Actual behaviour:**

We get a validation alert saying that the old and the new password must not be the same. Therefore forcing the user to enter a dummy value in the old password field.

![](https://www.evernote.com/shard/s340/sh/7a75d7f0-bc03-43e0-95a4-bc91c6f25740/b758998bebc3f247ca9f2b270987c1c9/deep/0/iOS-Simulator---iPhone-6---iPhone-6---iOS-8.1-(12B411).png)
