### PR TITLE
[RELEASE] 1.1.1

### DIFF
--- a/1PasswordExtension.podspec
+++ b/1PasswordExtension.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "1PasswordExtension"
-  s.version      = "1.1"
+  s.version      = "1.1.1"
   s.summary      = "With just a few lines of code, your app can add 1Password support."
 
   s.description  = <<-DESC

--- a/Demos/App Demo for iOS/App Demo for iOS/Info.plist
+++ b/Demos/App Demo for iOS/App Demo for iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0b1</string>
+	<string>1.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Demos/WebView Demo for iOS/WebView Demo for iOS/Info.plist
+++ b/Demos/WebView Demo for iOS/WebView Demo for iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -8,7 +8,7 @@
 #import "OnePasswordExtension.h"
 
 // Version
-#define VERSION_NUMBER @(110)
+#define VERSION_NUMBER @(111)
 static NSString *const AppExtensionVersionNumberKey = @"version_number";
 
 // Available App Extension Actions


### PR DESCRIPTION
[NEW] Added support for the iPhone 6 and 6 Plus for ACME and ACME Browser.
[NEW] Added support for Carthage in the [add-framework-support](https://github.com/AgileBits/onepassword-app-extension/tree/add-framework-support) branch.
[NEW] Added light cloured assets for the 1Password Button.

[IMPROVED] Updated filling code for the upcoming filling brain in 1Password. (1Password 5.3 betas are required)
[IMPROVED] We now validate that the new password and the old password are not the same when changing the password in ACME.
[IMPROVED] Minimized the scope of some string constants to help prevent "duplicate symbol" linker errors when this code is included more than once in an app (because one or more libraries includes this code).

[FIXED] Fixed problem where passwords containling `\` did not properly fill.
[FIXED] Removed the weak/strong self dance when not necessary.
[FIXED] Replaced the email for beta access alert with a link to get 1Password from the App Store when 1Password is not installed.
[FIXED] Fixed warning about multiple length methods in Xcode.
[FIXED] Fixed issue with some shadowed error variables.
