### PR TITLE
[RELEASE] 1.2

### DIFF
--- a/Demos/App Demo for iOS/App Demo for iOS/Info.plist
+++ b/Demos/App Demo for iOS/App Demo for iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Demos/Browser Filling Demo for iOS/Browser Filling Demo for iOS/Info.plist
+++ b/Demos/Browser Filling Demo for iOS/Browser Filling Demo for iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Demos/WebView Demo for iOS/WebView Demo for iOS/Info.plist
+++ b/Demos/WebView Demo for iOS/WebView Demo for iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -8,7 +8,7 @@
 #import "OnePasswordExtension.h"
 
 // Version
-#define VERSION_NUMBER @(112)
+#define VERSION_NUMBER @(120)
 static NSString *const AppExtensionVersionNumberKey = @"version_number";
 
 // Available App Extension Actions


### PR DESCRIPTION
[NEW] Added the all new [Fill into Browser capability](https://github.com/AgileBits/onepassword-app-extension#use-case-5-browser-filling-support). This enables the 1Password Extension to show alongside other activities and to fill Credit Cards and Identities into your browser's web views. {#186}
[NEW] Added Swift compatibility for CocoaPods 0.36 or later. {#182}

[IMPROVED] The latest and greatest filling Brain in 1Password 5.3 or later will automatically be used for the [Web View Login](https://github.com/AgileBits/onepassword-app-extension#use-case-4-web-view-login-support) and [Browser filling](https://github.com/AgileBits/onepassword-app-extension#use-case-5-browser-filling-support) capabilities when filling Logins, Credit Cards and Identities. {#171, #172, #178 and #184}
[IMPROVED] Updated the README, the [Best Practices](https://github.com/AgileBits/onepassword-app-extension#best-practices) and the in-code documentation in general. {#183 and #186}
[IMPROVED] Improved the in-code documentation and simplified the change password capability. {#185}
[IMPROVED] Added "facebook.com" as a quick link in **ACME Browser** for easier and faster testing. {#170}