### PR TITLE
Fixed compile time checks for backwards compatibility

### DIFF
--- a/Demos/App Demo for iOS/App Demo for iOS.xcodeproj/project.pbxproj
+++ b/Demos/App Demo for iOS/App Demo for iOS.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		C0F0C19519889479000B261F /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C0F0C19419889479000B261F /* Images.xcassets */; };
 		C0F0C19C198894F8000B261F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C0F0C19B198894F8000B261F /* main.m */; };
 		C0F0C19D19889519000B261F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C0F0C19619889498000B261F /* Main.storyboard */; };
+		D020FC181B004E1000F8ECFE /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D020FC171B004E1000F8ECFE /* WebKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +39,7 @@
 		C0F0C199198894ED000B261F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = "App Demo for iOS/App Demo for iOS/Info.plist"; sourceTree = "<group>"; };
 		C0F0C19B198894F8000B261F /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "App Demo for iOS/App Demo for iOS/main.m"; sourceTree = "<group>"; };
 		C0FA52971974821100570166 /* App Demo for iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "App Demo for iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D020FC171B004E1000F8ECFE /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -45,6 +47,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D020FC181B004E1000F8ECFE /* WebKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,6 +97,7 @@
 		C0FA529A1974821100570166 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				D020FC171B004E1000F8ECFE /* WebKit.framework */,
 				C0F0C199198894ED000B261F /* Info.plist */,
 				C0F0C19B198894F8000B261F /* main.m */,
 			);
@@ -276,6 +280,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "acme-anvil-corp";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				INFOPLIST_FILE = "$(SRCROOT)/App Demo for iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "App Demo for iOS";
 				TARGETED_DEVICE_FAMILY = 1;
@@ -288,6 +293,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "acme-anvil-corp";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				INFOPLIST_FILE = "$(SRCROOT)/App Demo for iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "App Demo for iOS";
 				TARGETED_DEVICE_FAMILY = 1;

--- a/Demos/WebView Demo for iOS/WebView Demo for iOS.xcodeproj/project.pbxproj
+++ b/Demos/WebView Demo for iOS/WebView Demo for iOS.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		C0F0C1AC198895C8000B261F /* welcome.html in Resources */ = {isa = PBXBuildFile; fileRef = C0F0C1AB198895C8000B261F /* welcome.html */; };
 		C0F0C1AF198895F6000B261F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C0F0C1AD198895F6000B261F /* Main.storyboard */; };
 		C0F0C1B319889604000B261F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C0F0C1B119889604000B261F /* main.m */; };
+		D020FC1A1B004E1F00F8ECFE /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D020FC191B004E1F00F8ECFE /* WebKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		C0F0C1AE198895F6000B261F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = "WebView Demo for iOS/Base.lproj/Main.storyboard"; sourceTree = SOURCE_ROOT; };
 		C0F0C1B019889604000B261F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = "WebView Demo for iOS/Info.plist"; sourceTree = SOURCE_ROOT; };
 		C0F0C1B119889604000B261F /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "WebView Demo for iOS/main.m"; sourceTree = SOURCE_ROOT; };
+		D020FC191B004E1F00F8ECFE /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -38,6 +40,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D020FC1A1B004E1F00F8ECFE /* WebKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -82,6 +85,7 @@
 		C0169CD8197D6C3C006E7618 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				D020FC191B004E1F00F8ECFE /* WebKit.framework */,
 				C0F0C1B019889604000B261F /* Info.plist */,
 				C0F0C1B119889604000B261F /* main.m */,
 			);
@@ -264,6 +268,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "acme-browser-corp";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				INFOPLIST_FILE = "$(SRCROOT)/WebView Demo for iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "WebView Demo for iOS";
 				TARGETED_DEVICE_FAMILY = 1;
@@ -276,6 +281,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "acme-browser-corp";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				INFOPLIST_FILE = "$(SRCROOT)/WebView Demo for iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "WebView Demo for iOS";
 				TARGETED_DEVICE_FAMILY = 1;

--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -38,10 +38,10 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 }
 
 - (BOOL)isSystemAppExtensionAPIAvailable {
-#ifdef __IPHONE_8_0
-	return NSClassFromString(@"NSExtensionItem") != nil;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+    return [NSExtensionItem class] != nil;
 #else
-	return NO;
+    return NO;
 #endif
 }
 
@@ -67,7 +67,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 		return;
 	}
 
-#ifdef __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
 	NSDictionary *item = @{ AppExtensionVersionNumberKey: VERSION_NUMBER, AppExtensionURLStringKey: URLString };
 
 	UIActivityViewController *activityViewController = [self activityViewControllerForItem:item viewController:viewController sender:sender typeIdentifier:kUTTypeAppExtensionFindLoginAction];
@@ -117,7 +117,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 	}
 
 
-#ifdef __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
 	NSMutableDictionary *newLoginAttributesDict = [NSMutableDictionary new];
 	newLoginAttributesDict[AppExtensionVersionNumberKey] = VERSION_NUMBER;
 	newLoginAttributesDict[AppExtensionURLStringKey] = URLString;
@@ -171,7 +171,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 		return;
 	}
 
-#ifdef __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
 	NSMutableDictionary *item = [NSMutableDictionary new];
 	item[AppExtensionVersionNumberKey] = VERSION_NUMBER;
 	item[AppExtensionURLStringKey] = URLString;
@@ -217,7 +217,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 	NSAssert(webView != nil, @"webView must not be nil");
 	NSAssert(viewController != nil, @"viewController must not be nil");
 
-#ifdef __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
 	if ([webView isKindOfClass:[UIWebView class]]) {
 		[self fillItemIntoUIWebView:webView webViewController:viewController sender:(id)sender showOnlyLogins:yesOrNo completion:^(BOOL success, NSError *error) {
 			if (completion) {
@@ -225,7 +225,6 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 			}
 		}];
 	}
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
 	else if ([webView isKindOfClass:[WKWebView class]]) {
 		[self fillItemIntoWKWebView:webView forViewController:viewController sender:(id)sender showOnlyLogins:yesOrNo completion:^(BOOL success, NSError *error) {
 			if (completion) {
@@ -233,7 +232,6 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 			}
 		}];
 	}
-#endif
 	else {
 		[NSException raise:@"Invalid argument: web view must be an instance of WKWebView or UIWebView." format:@""];
 	}
@@ -249,14 +247,13 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 - (void)createExtensionItemForWebView:(id)webView completion:(void (^)(NSExtensionItem *extensionItem, NSError *error))completion {
 	NSAssert(webView != nil, @"webView must not be nil");
 
-#ifdef __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
 	if ([webView isKindOfClass:[UIWebView class]]) {
 		UIWebView *uiWebView = (UIWebView *)webView;
 		NSString *collectedPageDetails = [uiWebView stringByEvaluatingJavaScriptFromString:OPWebViewCollectFieldsScript];
 
 		[self createExtensionItemForURLString:uiWebView.request.URL.absoluteString webPageDetails:collectedPageDetails completion:completion];
 	}
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
 	else if ([webView isKindOfClass:[WKWebView class]]) {
 		WKWebView *wkWebView = (WKWebView *)webView;
 		[wkWebView evaluateJavaScript:OPWebViewCollectFieldsScript completionHandler:^(NSString *result, NSError *evaluateError) {
@@ -280,7 +277,6 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 			[self createExtensionItemForURLString:wkWebView.URL.absoluteString webPageDetails:result completion:completion];
 		}];
 	}
-#endif
 	else {
 		[NSException raise:@"Invalid argument: web view must be an instance of WKWebView or UIWebView." format:@""];
 	}
@@ -382,7 +378,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 	[forViewController presentViewController:activityViewController animated:YES completion:nil];
 }
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
 - (void)fillItemIntoWKWebView:(WKWebView *)webView forViewController:(UIViewController *)viewController sender:(id)sender showOnlyLogins:(BOOL)yesOrNo completion:(void (^)(BOOL success, NSError *error))completion {
 	[webView evaluateJavaScript:OPWebViewCollectFieldsScript completionHandler:^(NSString *result, NSError *error) {
 		if (!result) {
@@ -442,7 +438,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 		return;
 	}
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
 	if ([webView isKindOfClass:[WKWebView class]]) {
 		[((WKWebView *)webView) evaluateJavaScript:scriptSource completionHandler:^(NSString *result, NSError *evaluationError) {
 			BOOL success = (result != nil);
@@ -465,7 +461,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 	[NSException raise:@"Invalid argument: web view must be an instance of WKWebView or UIWebView." format:@""];
 }
 
-#ifdef __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
 - (void)processExtensionItem:(NSExtensionItem *)extensionItem completion:(void (^)(NSDictionary *loginDictionary, NSError *error))completion {
 	if (extensionItem.attachments.count == 0) {
 		NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: @"Unexpected data returned by App Extension: extension item had no attachments." };
@@ -509,7 +505,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 }
 
 - (UIActivityViewController *)activityViewControllerForItem:(NSDictionary *)item viewController:(UIViewController*)viewController sender:(id)sender typeIdentifier:(NSString *)typeIdentifier {
-#ifdef __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
 
 	NSItemProvider *itemProvider = [[NSItemProvider alloc] initWithItem:item typeIdentifier:typeIdentifier];
 


### PR DESCRIPTION
We compile this library into some shared code that has a deployment target of iOS 7.0, and then use it with a `WKWebView` on iOS 8.0+. Before these changes, the OnePassword extension code would crash.

I made a few changes to fix this:

1. Checking `#ifdef __IPHONE_8_0` is not directly checking if the base SDK is greater than or equal to 8.0. I replaced these checks with `__IPHONE_OS_VERSION_MAX_ALLOWED >= 80000`, which is the standard for doing this.
2. I replaced `NSClassFromString(@"NSExtensionItem")` with `[NSExtensionItem class]`, because it is marked with `NS_CLASS_AVAILABLE`, which automatically marks the symbol as weak if the deployment target is less than 8.0
3. I replaced the compile time check for the deployment version to be greater than 8.0, due to the issue we were experiencing above. This will not cause any crashes because `WebKit` is marked as a `weak_framework` in the Podspec, so that `[WKWebView class]` will just evaluate to `nil` on iOS 7.0.