### PR TITLE
[NEW] Added ability to use WKWebView when the Deployment Target is iOS 7.1 or earlier

### DIFF
--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -226,7 +226,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 			}
 		}];
 	}
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0 || ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW
 	else if ([webView isKindOfClass:[WKWebView class]]) {
 		[self fillItemIntoWKWebView:webView forViewController:viewController sender:(id)sender showOnlyLogins:yesOrNo completion:^(BOOL success, NSError *error) {
 			if (completion) {
@@ -257,7 +257,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 
 		[self createExtensionItemForURLString:uiWebView.request.URL.absoluteString webPageDetails:collectedPageDetails completion:completion];
 	}
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0 || ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW
 	else if ([webView isKindOfClass:[WKWebView class]]) {
 		WKWebView *wkWebView = (WKWebView *)webView;
 		[wkWebView evaluateJavaScript:OPWebViewCollectFieldsScript completionHandler:^(NSString *result, NSError *evaluateError) {
@@ -383,7 +383,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 	[forViewController presentViewController:activityViewController animated:YES completion:nil];
 }
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0 || ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW
 - (void)fillItemIntoWKWebView:(WKWebView *)webView forViewController:(UIViewController *)viewController sender:(id)sender showOnlyLogins:(BOOL)yesOrNo completion:(void (^)(BOOL success, NSError *error))completion {
 	[webView evaluateJavaScript:OPWebViewCollectFieldsScript completionHandler:^(NSString *result, NSError *error) {
 		if (!result) {
@@ -443,7 +443,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 		return;
 	}
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0 || ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW
 	if ([webView isKindOfClass:[WKWebView class]]) {
 		[((WKWebView *)webView) evaluateJavaScript:scriptSource completionHandler:^(NSString *result, NSError *evaluationError) {
 			BOOL success = (result != nil);

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ If your project's Deployment Target is earlier than iOS 8.0, please make sure th
 
 #### WKWebView support for projects with iOS 7.1 or earler as the Deployment Target
 
-If your project's **Deployment Target** is `7.1` or earlier and you are using `WKWebViews` on iOS 8 devices (runtime checks), you need to add `ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW=1` to your project's `Preprocessor Macros`.
+If the **Deployment Target** is `7.1` or earlier in your project or target and you are using `WKWebViews` for iOS 8 devices (runtime checks), you simply need to add `ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW=1` to your `Preprocessor Macros`.
 
 <a href="https://vimeo.com/102142106" target="_blank"><img src="https://www.evernote.com/l/AVTawUykz6dHea_aKawqBwTCza2zvJYbeVMB/image.png" width="640"></a>
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ If your project's Deployment Target is earlier than iOS 8.0, please make sure th
 
 <a href="https://vimeo.com/102142106" target="_blank"><img src="https://www.evernote.com/shard/s340/sh/7547419d-6c49-4b45-bdb1-575c28678164/49cb7e0c1f508d1f67f5cf0361d58d3a/deep/0/WebView-Demo-for-iOS.xcodeproj.png" width="640"></a>
 
-##### WKWebView support for projects with iOS 7.1 or earler as the Deployment Target
+#### WKWebView support for projects with iOS 7.1 or earler as the Deployment Target
 
 If your project's **Deployment Target** is `7.1` or earlier and you are using `WKWebViews` on iOS 8 devices (runtime checks), you need to add `ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW=1` to your project's `Preprocessor Macros`.
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ If your project's Deployment Target is earlier than iOS 8.0, please make sure th
 
 #### WKWebView support for projects with iOS 7.1 or earler as the Deployment Target
 
-If the **Deployment Target** is `7.1` or earlier in your project or target and you are using `WKWebViews` for iOS 8 devices (runtime checks), you simply need to add `ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW=1` to your `Preprocessor Macros`.
+If the **Deployment Target** is `7.1` or earlier in your project or target and you are using `WKWebViews` (runtime checks for iOS 8 deveices), you simply need to add `ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW=1` to your `Preprocessor Macros`.
 
 <a href="https://vimeo.com/102142106" target="_blank"><img src="https://www.evernote.com/l/AVTawUykz6dHea_aKawqBwTCza2zvJYbeVMB/image.png" width="640"></a>
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ If your project's Deployment Target is earlier than iOS 8.0, please make sure th
 
 <a href="https://vimeo.com/102142106" target="_blank"><img src="https://www.evernote.com/shard/s340/sh/7547419d-6c49-4b45-bdb1-575c28678164/49cb7e0c1f508d1f67f5cf0361d58d3a/deep/0/WebView-Demo-for-iOS.xcodeproj.png" width="640"></a>
 
+##### WKWebView support for projects with iOS 7.1 or earler as the Deployment Target
+
+If your project's **Deployment Target** is `7.1` or earlier and you are using `WKWebViews` on iOS 8 devices (runtime checks), you need to add `ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW=1` to your project's `Preprocessor Macros`.
+
+<a href="https://vimeo.com/102142106" target="_blank"><img src="https://www.evernote.com/l/AVTawUykz6dHea_aKawqBwTCza2zvJYbeVMB/image.png" width="640"></a>
+
 ## Best Practices
 
 * Use the same `URLString` during Registration and Login.


### PR DESCRIPTION
See the README instructions about [WKWebView support for projects with iOS 7.1 or earler as the Deployment Target](https://github.com/AgileBits/onepassword-app-extension/tree/add-ability-to-enable-wk-webview-for-older-os-versions#wkwebview-support-for-projects-with-ios-71-or-earler-as-the-deployment-target)

This should resolve #212.