### PR TITLE
Improvements for the password generator options.

### DIFF
--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -78,10 +78,10 @@
 												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
 
 												// Here are all the symbols available in the the 1Password Password Generator:
-												// @"!", @"@", @"#", @"$", @"%", @"^", @"&", @"*", @"(", @")", @"_", @"-", @"+", @"=", @"|", @"[", @"]", @"{", @"}", @"'", @"\"", @;", @".". @",", @">", @"?", @"/", @"~", @"`"
-												// The array for AppExtensionGeneratedPasswordForbiddenSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
+												// !@#$%^&*()_-+=|[]{}'\";.,>?/~`
+												// The string for AppExtensionGeneratedPasswordForbiddenSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
 
-												AppExtensionGeneratedPasswordForbiddenSymbolsKey: @[@"&", @"*", @"@"]
+												AppExtensionGeneratedPasswordForbiddenSymbolsKey: @"!@#$%/"
 												};
 
 	[[OnePasswordExtension sharedExtension] changePasswordForLoginForURLString:@"https://www.acme.com" loginDetails:loginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -63,7 +63,7 @@
 									  AppExtensionNotesKey: @"Saved with the ACME app", // Optional, used for the third schenario only
 									};
 
-	// Password generation options are optional, but are very handy in case you have strict rules about password lengths
+	// The password generation options are optional, but are very handy in case you have strict rules about password lengths, symbols and digits.
 	NSDictionary *passwordGenerationOptions = @{
 												AppExtensionGeneratedPasswordMinLengthKey: @(8),
 												AppExtensionGeneratedPasswordMaxLengthKey: @(30),

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -67,7 +67,11 @@
 	NSDictionary *passwordGenerationOptions = @{
 												AppExtensionGeneratedPasswordMinLengthKey: @(8),
 												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
+
+												// If YES the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO with not exculde digits from the generated password.
 												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
+
+												// If YES the 1Password will guarantee that the generated password will contain at least one symbol (See the list bellow). Passing NO with not exculde symbols from the generated password.
 												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
 
 												// Here are all the symbols available in the the 1Password Password Generator:

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -70,7 +70,7 @@
 												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
 												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
 
-												// Here are all the symbols used by the 1Password generator:
+												// Here are all the symbols available in the the 1Password Password Generator:
 												// @"!", @"@", @"#", @"$", @"%", @"^", @"&", @"*", @"(", @")", @"_", @"-", @"+", @"=", @"|", @"[", @"]", @"{", @"}", @"'", @"\"", @;", @".". @",", @">", @"?", @"/", @"~", @"`"
 												// The array for AppExtensionGeneratedPasswordBlacklistedSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
 

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -65,7 +65,10 @@
 
 	// The password generation options are optional, but are very handy in case you have strict rules about password lengths, symbols and digits.
 	NSDictionary *passwordGenerationOptions = @{
+												// The minimum password length can be 4 or more.
 												AppExtensionGeneratedPasswordMinLengthKey: @(8),
+
+												// The maximum password length can be 50 or less.
 												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
 
 												// If YES, the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO will not exclude digits from the generated password.

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -81,7 +81,7 @@
 												// @"!", @"@", @"#", @"$", @"%", @"^", @"&", @"*", @"(", @")", @"_", @"-", @"+", @"=", @"|", @"[", @"]", @"{", @"}", @"'", @"\"", @;", @".". @",", @">", @"?", @"/", @"~", @"`"
 												// The array for AppExtensionGeneratedPasswordBlacklistedSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
 
-												AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@", @"#", @"~", @"`", @"$", @"^", @"/", @"|", @"<", @">", @":", @";"]
+												AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@"]
 												};
 
 	[[OnePasswordExtension sharedExtension] changePasswordForLoginForURLString:@"https://www.acme.com" loginDetails:loginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -32,18 +32,18 @@
 }
 
 - (IBAction)changePasswordIn1Password:(id)sender {
-	NSString *newPassword = self.freshPasswordTextField.text ? : @"";
+	NSString *changedPassword = self.freshPasswordTextField.text ? : @"";
 	NSString *oldPassword = self.oldPasswordTextField.text ? : @"";
 	NSString *confirmationPassword = self.confirmPasswordTextField.text ? : @"";
 
 	// Validate that the new password and the old password are not the same.
-	if (oldPassword.length > 0 && [oldPassword isEqualToString:newPassword]) {
+	if (oldPassword.length > 0 && [oldPassword isEqualToString:changedPassword]) {
 		[self showChangePasswordFailedAlertWithMessage:@"The old and the new password must not be the same"];
 		return;
 	}
 
 	// Validate that the new and confirmation passwords match.
-	if (NO == [newPassword isEqualToString:confirmationPassword]) {
+	if (NO == [changedPassword isEqualToString:confirmationPassword]) {
 		[self showChangePasswordFailedAlertWithMessage:@"The new passwords and the confirmation password must match"];
 		return;
 	}
@@ -58,7 +58,7 @@
 	NSDictionary *loginDetails = @{
 									  AppExtensionTitleKey: @"ACME", // Optional, used for the third schenario only
 									  AppExtensionUsernameKey: @"aUsername", // Optional, used for the third schenario only
-									  AppExtensionPasswordKey: newPassword,
+									  AppExtensionPasswordKey: changedPassword,
 									  AppExtensionOldPasswordKey: oldPassword,
 									  AppExtensionNotesKey: @"Saved with the ACME app", // Optional, used for the third schenario only
 									};

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -79,9 +79,9 @@
 
 												// Here are all the symbols available in the the 1Password Password Generator:
 												// !@#$%^&*()_-+=|[]{}'\";.,>?/~`
-												// The string for AppExtensionGeneratedPasswordForbiddenSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
+												// The string for AppExtensionGeneratedPasswordForbiddenCharactersKey should contain the symbols and characters that you wish 1Password to exclude from the generated password.
 
-												AppExtensionGeneratedPasswordForbiddenSymbolsKey: @"!@#$%/"
+												AppExtensionGeneratedPasswordForbiddenCharactersKey: @"!@#$%/0lIO"
 												};
 
 	[[OnePasswordExtension sharedExtension] changePasswordForLoginForURLString:@"https://www.acme.com" loginDetails:loginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -79,9 +79,9 @@
 
 												// Here are all the symbols available in the the 1Password Password Generator:
 												// @"!", @"@", @"#", @"$", @"%", @"^", @"&", @"*", @"(", @")", @"_", @"-", @"+", @"=", @"|", @"[", @"]", @"{", @"}", @"'", @"\"", @;", @".". @",", @">", @"?", @"/", @"~", @"`"
-												// The array for AppExtensionGeneratedPasswordBlacklistedSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
+												// The array for AppExtensionGeneratedPasswordForbiddenSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
 
-												AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@"]
+												AppExtensionGeneratedPasswordForbiddenSymbolsKey: @[@"&", @"*", @"@"]
 												};
 
 	[[OnePasswordExtension sharedExtension] changePasswordForLoginForURLString:@"https://www.acme.com" loginDetails:loginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -68,10 +68,10 @@
 												AppExtensionGeneratedPasswordMinLengthKey: @(8),
 												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
 
-												// If YES the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO with not exculde digits from the generated password.
+												// If YES, the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO will not exclude digits from the generated password.
 												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
 
-												// If YES the 1Password will guarantee that the generated password will contain at least one symbol (See the list bellow). Passing NO with not exculde symbols from the generated password.
+												// If YES, the 1Password will guarantee that the generated password will contain at least one symbol (See the list bellow). Passing NO with will exclude symbols from the generated password.
 												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
 
 												// Here are all the symbols available in the the 1Password Password Generator:

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -65,8 +65,16 @@
 
 	// Password generation options are optional, but are very handy in case you have strict rules about password lengths
 	NSDictionary *passwordGenerationOptions = @{
-												AppExtensionGeneratedPasswordMinLengthKey: @(6), // The minimum value can be 4 or more
-												AppExtensionGeneratedPasswordMaxLengthKey: @(50) // The maximum value can be 50 or less
+												AppExtensionGeneratedPasswordMinLengthKey: @(8),
+												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
+												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
+												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
+
+												// Here are all the symbols used by the 1Password generator:
+												// @"!", @"@", @"#", @"$", @"%", @"^", @"&", @"*", @"(", @")", @"_", @"-", @"+", @"=", @"|", @"[", @"]", @"{", @"}", @"'", @"\"", @;", @".". @",", @">", @"?", @"/", @"~", @"`"
+												// The array for AppExtensionGeneratedPasswordBlacklistedSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
+
+												AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@", @"#", @"~", @"`", @"$", @"^", @"/", @"|", @"<", @">", @":", @";"]
 												};
 
 	[[OnePasswordExtension sharedExtension] changePasswordForLoginForURLString:@"https://www.acme.com" loginDetails:loginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {

--- a/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/ChangePasswordViewController.m
@@ -72,10 +72,10 @@
 												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
 
 												// If YES, the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO will not exclude digits from the generated password.
-												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
+												AppExtensionGeneratedPasswordRequireDigitsKey: @(YES),
 
 												// If YES, the 1Password will guarantee that the generated password will contain at least one symbol (See the list bellow). Passing NO with will exclude symbols from the generated password.
-												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
+												AppExtensionGeneratedPasswordRequireSymbolsKey: @(YES),
 
 												// Here are all the symbols available in the the 1Password Password Generator:
 												// !@#$%^&*()_-+=|[]{}'\";.,>?/~`

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -63,9 +63,9 @@
 
 												// Here are all the symbols available in the the 1Password Password Generator:
 												// @"!", @"@", @"#", @"$", @"%", @"^", @"&", @"*", @"(", @")", @"_", @"-", @"+", @"=", @"|", @"[", @"]", @"{", @"}", @"'", @"\"", @;", @".". @",", @">", @"?", @"/", @"~", @"`"
-												// The array for AppExtensionGeneratedPasswordBlacklistedSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
+												// The array for AppExtensionGeneratedPasswordForbiddenSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
 
-												AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@"]
+												AppExtensionGeneratedPasswordForbiddenSymbolsKey: @[@"&", @"*", @"@"]
 												};
 
 	[[OnePasswordExtension sharedExtension] storeLoginForURLString:@"https://www.acme.com" loginDetails:newLoginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -51,7 +51,11 @@
 	NSDictionary *passwordGenerationOptions = @{
 		AppExtensionGeneratedPasswordMinLengthKey: @(8),
 		AppExtensionGeneratedPasswordMaxLengthKey: @(30),
+
+		// If YES the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO with not exculde digits from the generated password.
 		AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
+
+		// If YES the 1Password will guarantee that the generated password will contain at least one symbol (See the list bellow). Passing NO with not exculde symbols from the generated password.
 		AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
 
 		// Here are all the symbols available in the the 1Password Password Generator:

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -65,7 +65,7 @@
 												// @"!", @"@", @"#", @"$", @"%", @"^", @"&", @"*", @"(", @")", @"_", @"-", @"+", @"=", @"|", @"[", @"]", @"{", @"}", @"'", @"\"", @;", @".". @",", @">", @"?", @"/", @"~", @"`"
 												// The array for AppExtensionGeneratedPasswordBlacklistedSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
 
-												AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@", @"#", @"~", @"`", @"$", @"^", @"/", @"|", @"<", @">", @":", @";"]
+												AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@"]
 												};
 
 	[[OnePasswordExtension sharedExtension] storeLoginForURLString:@"https://www.acme.com" loginDetails:newLoginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -47,7 +47,7 @@
 											  }
 									  };
 
-	// Password generation options are optional, but are very handy in case you have strict rules about password lengths
+	// The password generation options are optional, but are very handy in case you have strict rules about password lengths, symbols and digits.
 	NSDictionary *passwordGenerationOptions = @{
 		AppExtensionGeneratedPasswordMinLengthKey: @(8),
 		AppExtensionGeneratedPasswordMaxLengthKey: @(30),

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -63,9 +63,9 @@
 
 												// Here are all the symbols available in the the 1Password Password Generator:
 												// !@#$%^&*()_-+=|[]{}'\";.,>?/~`
-												// The string for AppExtensionGeneratedPasswordForbiddenSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
+												// The string for AppExtensionGeneratedPasswordForbiddenCharactersKey should contain the symbols and characters that you wish 1Password to exclude from the generated password.
 
-												AppExtensionGeneratedPasswordForbiddenSymbolsKey: @"!@#$%/"
+												AppExtensionGeneratedPasswordForbiddenCharactersKey: @"!@#$%/0lIO"
 												};
 
 	[[OnePasswordExtension sharedExtension] storeLoginForURLString:@"https://www.acme.com" loginDetails:newLoginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -62,10 +62,10 @@
 												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
 
 												// Here are all the symbols available in the the 1Password Password Generator:
-												// @"!", @"@", @"#", @"$", @"%", @"^", @"&", @"*", @"(", @")", @"_", @"-", @"+", @"=", @"|", @"[", @"]", @"{", @"}", @"'", @"\"", @;", @".". @",", @">", @"?", @"/", @"~", @"`"
-												// The array for AppExtensionGeneratedPasswordForbiddenSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
+												// !@#$%^&*()_-+=|[]{}'\";.,>?/~`
+												// The string for AppExtensionGeneratedPasswordForbiddenSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
 
-												AppExtensionGeneratedPasswordForbiddenSymbolsKey: @[@"&", @"*", @"@"]
+												AppExtensionGeneratedPasswordForbiddenSymbolsKey: @"!@#$%/"
 												};
 
 	[[OnePasswordExtension sharedExtension] storeLoginForURLString:@"https://www.acme.com" loginDetails:newLoginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -56,10 +56,10 @@
 												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
 
 												// If YES, the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO will not exclude digits from the generated password.
-												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
+												AppExtensionGeneratedPasswordRequireDigitsKey: @(YES),
 
 												// If YES, the 1Password will guarantee that the generated password will contain at least one symbol (See the list bellow). Passing NO with will exclude symbols from the generated password.
-												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
+												AppExtensionGeneratedPasswordRequireSymbolsKey: @(YES),
 
 												// Here are all the symbols available in the the 1Password Password Generator:
 												// !@#$%^&*()_-+=|[]{}'\";.,>?/~`

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -49,9 +49,17 @@
 
 	// Password generation options are optional, but are very handy in case you have strict rules about password lengths
 	NSDictionary *passwordGenerationOptions = @{
-												AppExtensionGeneratedPasswordMinLengthKey: @(6), // The minimum value can be 4 or more
-												AppExtensionGeneratedPasswordMaxLengthKey: @(50) // The maximum value can be 50 or less
-												};
+		AppExtensionGeneratedPasswordMinLengthKey: @(8),
+		AppExtensionGeneratedPasswordMaxLengthKey: @(30),
+		AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
+		AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
+		
+		// Here are all the symbols used by the 1Password generator:
+		// @"!", @"@", @"#", @"$", @"%", @"^", @"&", @"*", @"(", @")", @"_", @"-", @"+", @"=", @"|", @"[", @"]", @"{", @"}", @"'", @"\"", @;", @".". @",", @">", @"?", @"/", @"~", @"`"
+		// The array for AppExtensionGeneratedPasswordBlacklistedSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
+
+		AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@", @"#", @"~", @"`", @"$", @"^", @"/", @"|", @"<", @">", @":", @";"]
+	};
 
 	[[OnePasswordExtension sharedExtension] storeLoginForURLString:@"https://www.acme.com" loginDetails:newLoginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {
 

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -53,8 +53,8 @@
 		AppExtensionGeneratedPasswordMaxLengthKey: @(30),
 		AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
 		AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
-		
-		// Here are all the symbols used by the 1Password generator:
+
+		// Here are all the symbols available in the the 1Password Password Generator:
 		// @"!", @"@", @"#", @"$", @"%", @"^", @"&", @"*", @"(", @")", @"_", @"-", @"+", @"=", @"|", @"[", @"]", @"{", @"}", @"'", @"\"", @;", @".". @",", @">", @"?", @"/", @"~", @"`"
 		// The array for AppExtensionGeneratedPasswordBlacklistedSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
 

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -52,10 +52,10 @@
 		AppExtensionGeneratedPasswordMinLengthKey: @(8),
 		AppExtensionGeneratedPasswordMaxLengthKey: @(30),
 
-		// If YES the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO with not exculde digits from the generated password.
+		// If YES, the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO will not exclude digits from the generated password.
 		AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
 
-		// If YES the 1Password will guarantee that the generated password will contain at least one symbol (See the list bellow). Passing NO with not exculde symbols from the generated password.
+		// If YES, the 1Password will guarantee that the generated password will contain at least one symbol (See the list bellow). Passing NO with will exclude symbols from the generated password.
 		AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
 
 		// Here are all the symbols available in the the 1Password Password Generator:

--- a/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
+++ b/Demos/App Demo for iOS/App Demo for iOS/RegisterViewController.m
@@ -49,21 +49,24 @@
 
 	// The password generation options are optional, but are very handy in case you have strict rules about password lengths, symbols and digits.
 	NSDictionary *passwordGenerationOptions = @{
-		AppExtensionGeneratedPasswordMinLengthKey: @(8),
-		AppExtensionGeneratedPasswordMaxLengthKey: @(30),
+												// The minimum password length can be 4 or more.
+												AppExtensionGeneratedPasswordMinLengthKey: @(8),
+												
+												// The maximum password length can be 50 or less.
+												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
 
-		// If YES, the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO will not exclude digits from the generated password.
-		AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
+												// If YES, the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO will not exclude digits from the generated password.
+												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
 
-		// If YES, the 1Password will guarantee that the generated password will contain at least one symbol (See the list bellow). Passing NO with will exclude symbols from the generated password.
-		AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
+												// If YES, the 1Password will guarantee that the generated password will contain at least one symbol (See the list bellow). Passing NO with will exclude symbols from the generated password.
+												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
 
-		// Here are all the symbols available in the the 1Password Password Generator:
-		// @"!", @"@", @"#", @"$", @"%", @"^", @"&", @"*", @"(", @")", @"_", @"-", @"+", @"=", @"|", @"[", @"]", @"{", @"}", @"'", @"\"", @;", @".". @",", @">", @"?", @"/", @"~", @"`"
-		// The array for AppExtensionGeneratedPasswordBlacklistedSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
+												// Here are all the symbols available in the the 1Password Password Generator:
+												// @"!", @"@", @"#", @"$", @"%", @"^", @"&", @"*", @"(", @")", @"_", @"-", @"+", @"=", @"|", @"[", @"]", @"{", @"}", @"'", @"\"", @;", @".". @",", @">", @"?", @"/", @"~", @"`"
+												// The array for AppExtensionGeneratedPasswordBlacklistedSymbolsKey should contain the symbols that you wish 1Password to exclude from the generated password.
 
-		AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@", @"#", @"~", @"`", @"$", @"^", @"/", @"|", @"<", @">", @":", @";"]
-	};
+												AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@", @"#", @"~", @"`", @"$", @"^", @"/", @"|", @"<", @">", @":", @";"]
+												};
 
 	[[OnePasswordExtension sharedExtension] storeLoginForURLString:@"https://www.acme.com" loginDetails:newLoginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {
 

--- a/OnePasswordExtension.h
+++ b/OnePasswordExtension.h
@@ -31,7 +31,7 @@
 #define AppExtensionGeneratedPasswordMaxLengthKey @"password_max_length"
 #define AppExtensionGeneratedPasswordUseDigitsKey @"password_use_digits"
 #define AppExtensionGeneratedPasswordUseSymbolsKey @"password_use_symbols"
-#define AppExtensionGeneratedPasswordBlacklistedSymbolsKey @"password_backlisted_symbols"
+#define AppExtensionGeneratedPasswordForbiddenSymbolsKey @"password_forbidden_symbols"
 
 // Errors codes
 #define AppExtensionErrorDomain                   @"OnePasswordExtension"

--- a/OnePasswordExtension.h
+++ b/OnePasswordExtension.h
@@ -16,27 +16,27 @@
 NS_ASSUME_NONNULL_BEGIN
 
 // Login Dictionary keys - Used to get or set the properties of a 1Password Login
-#define AppExtensionURLStringKey                  @"url_string"
-#define AppExtensionUsernameKey                   @"username"
-#define AppExtensionPasswordKey                   @"password"
-#define AppExtensionTOTPKey                       @"totp"
-#define AppExtensionTitleKey                      @"login_title"
-#define AppExtensionNotesKey                      @"notes"
-#define AppExtensionSectionTitleKey               @"section_title"
-#define AppExtensionFieldsKey                     @"fields"
-#define AppExtensionReturnedFieldsKey             @"returned_fields"
-#define AppExtensionOldPasswordKey                @"old_password"
-#define AppExtensionPasswordGeneratorOptionsKey   @"password_generator_options"
+#define AppExtensionURLStringKey                         @"url_string"
+#define AppExtensionUsernameKey                          @"username"
+#define AppExtensionPasswordKey                          @"password"
+#define AppExtensionTOTPKey                              @"totp"
+#define AppExtensionTitleKey                             @"login_title"
+#define AppExtensionNotesKey                             @"notes"
+#define AppExtensionSectionTitleKey                      @"section_title"
+#define AppExtensionFieldsKey                            @"fields"
+#define AppExtensionReturnedFieldsKey                    @"returned_fields"
+#define AppExtensionOldPasswordKey                       @"old_password"
+#define AppExtensionPasswordGeneratorOptionsKey          @"password_generator_options"
 
 // Password Generator options - Used to set the 1Password Password Generator options when saving a new Login or when changing the password for for an existing Login
-#define AppExtensionGeneratedPasswordMinLengthKey @"password_min_length"
-#define AppExtensionGeneratedPasswordMaxLengthKey @"password_max_length"
-#define AppExtensionGeneratedPasswordUseDigitsKey @"password_use_digits"
-#define AppExtensionGeneratedPasswordUseSymbolsKey @"password_use_symbols"
+#define AppExtensionGeneratedPasswordMinLengthKey        @"password_min_length"
+#define AppExtensionGeneratedPasswordMaxLengthKey        @"password_max_length"
+#define AppExtensionGeneratedPasswordRequireDigitsKey    @"password_require_digits"
+#define AppExtensionGeneratedPasswordRequireSymbolsKey   @"password_require_symbols"
 #define AppExtensionGeneratedPasswordForbiddenSymbolsKey @"password_forbidden_symbols"
 
 // Errors codes
-#define AppExtensionErrorDomain                   @"OnePasswordExtension"
+#define AppExtensionErrorDomain                          @"OnePasswordExtension"
 
 #define AppExtensionErrorCodeCancelledByUser                    0
 #define AppExtensionErrorCodeAPINotAvailable                    1

--- a/OnePasswordExtension.h
+++ b/OnePasswordExtension.h
@@ -16,27 +16,27 @@
 NS_ASSUME_NONNULL_BEGIN
 
 // Login Dictionary keys - Used to get or set the properties of a 1Password Login
-#define AppExtensionURLStringKey                         @"url_string"
-#define AppExtensionUsernameKey                          @"username"
-#define AppExtensionPasswordKey                          @"password"
-#define AppExtensionTOTPKey                              @"totp"
-#define AppExtensionTitleKey                             @"login_title"
-#define AppExtensionNotesKey                             @"notes"
-#define AppExtensionSectionTitleKey                      @"section_title"
-#define AppExtensionFieldsKey                            @"fields"
-#define AppExtensionReturnedFieldsKey                    @"returned_fields"
-#define AppExtensionOldPasswordKey                       @"old_password"
-#define AppExtensionPasswordGeneratorOptionsKey          @"password_generator_options"
+#define AppExtensionURLStringKey                            @"url_string"
+#define AppExtensionUsernameKey                             @"username"
+#define AppExtensionPasswordKey                             @"password"
+#define AppExtensionTOTPKey                                 @"totp"
+#define AppExtensionTitleKey                                @"login_title"
+#define AppExtensionNotesKey                                @"notes"
+#define AppExtensionSectionTitleKey                         @"section_title"
+#define AppExtensionFieldsKey                               @"fields"
+#define AppExtensionReturnedFieldsKey                       @"returned_fields"
+#define AppExtensionOldPasswordKey                          @"old_password"
+#define AppExtensionPasswordGeneratorOptionsKey             @"password_generator_options"
 
 // Password Generator options - Used to set the 1Password Password Generator options when saving a new Login or when changing the password for for an existing Login
-#define AppExtensionGeneratedPasswordMinLengthKey        @"password_min_length"
-#define AppExtensionGeneratedPasswordMaxLengthKey        @"password_max_length"
-#define AppExtensionGeneratedPasswordRequireDigitsKey    @"password_require_digits"
-#define AppExtensionGeneratedPasswordRequireSymbolsKey   @"password_require_symbols"
+#define AppExtensionGeneratedPasswordMinLengthKey           @"password_min_length"
+#define AppExtensionGeneratedPasswordMaxLengthKey           @"password_max_length"
+#define AppExtensionGeneratedPasswordRequireDigitsKey       @"password_require_digits"
+#define AppExtensionGeneratedPasswordRequireSymbolsKey      @"password_require_symbols"
 #define AppExtensionGeneratedPasswordForbiddenCharactersKey @"password_forbidden_characters"
 
 // Errors codes
-#define AppExtensionErrorDomain                          @"OnePasswordExtension"
+#define AppExtensionErrorDomain                             @"OnePasswordExtension"
 
 #define AppExtensionErrorCodeCancelledByUser                    0
 #define AppExtensionErrorCodeAPINotAvailable                    1

--- a/OnePasswordExtension.h
+++ b/OnePasswordExtension.h
@@ -29,6 +29,9 @@
 // Password Generator options - Used to set the 1Password Password Generator options when saving a new Login or when changing the password for for an existing Login
 #define AppExtensionGeneratedPasswordMinLengthKey @"password_min_length"
 #define AppExtensionGeneratedPasswordMaxLengthKey @"password_max_length"
+#define AppExtensionGeneratedPasswordUseDigitsKey @"password_use_digits"
+#define AppExtensionGeneratedPasswordUseSymbolsKey @"password_use_symbols"
+#define AppExtensionGeneratedPasswordBlacklistedSymbolsKey @"password_backlisted_symbols"
 
 // Errors codes
 #define AppExtensionErrorDomain                   @"OnePasswordExtension"

--- a/OnePasswordExtension.h
+++ b/OnePasswordExtension.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 #define AppExtensionGeneratedPasswordMaxLengthKey        @"password_max_length"
 #define AppExtensionGeneratedPasswordRequireDigitsKey    @"password_require_digits"
 #define AppExtensionGeneratedPasswordRequireSymbolsKey   @"password_require_symbols"
-#define AppExtensionGeneratedPasswordForbiddenSymbolsKey @"password_forbidden_symbols"
+#define AppExtensionGeneratedPasswordForbiddenCharactersKey @"password_forbidden_characters"
 
 // Errors codes
 #define AppExtensionErrorDomain                          @"OnePasswordExtension"

--- a/README.md
+++ b/README.md
@@ -150,11 +150,23 @@ Adding 1Password to your registration screen is very similar to adding 1Password
 
 	// The password generation options are optional, but are very handy in case you have strict rules about password lengths, symbols and digits.
 	NSDictionary *passwordGenerationOptions = @{
+												// The minimum password length can be 4 or more.
 												AppExtensionGeneratedPasswordMinLengthKey: @(8),
+												
+												// The maximum password length can be 50 or less.
 												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
-												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
-												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
-												AppExtensionGeneratedPasswordForbiddenSymbolsKey: @"!@#$%/"												
+
+												// If YES, the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO will not exclude digits from the generated password.
+												AppExtensionGeneratedPasswordRequireDigitsKey: @(YES),
+
+												// If YES, the 1Password will guarantee that the generated password will contain at least one symbol (See the list bellow). Passing NO with will exclude symbols from the generated password.
+												AppExtensionGeneratedPasswordRequireSymbolsKey: @(YES),
+
+												// Here are all the symbols available in the the 1Password Password Generator:
+												// !@#$%^&*()_-+=|[]{}'\";.,>?/~`
+												// The string for AppExtensionGeneratedPasswordForbiddenCharactersKey should contain the symbols and characters that you wish 1Password to exclude from the generated password.
+
+												AppExtensionGeneratedPasswordForbiddenCharactersKey: @"!@#$%/0lIO"
 												};
 
 	[[OnePasswordExtension sharedExtension] storeLoginForURLString:@"https://www.acme.com" loginDetails:newLoginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {
@@ -187,24 +199,56 @@ Adding 1Password to your change password screen is very similar to adding 1Passw
 
 ```objective-c
 - (IBAction)changePasswordIn1Password:(id)sender {
-	NSString *newPassword = self.freshPasswordTextField.text ? : @"";
+	NSString *changedPassword = self.freshPasswordTextField.text ? : @"";
 	NSString *oldPassword = self.oldPasswordTextField.text ? : @"";
+	NSString *confirmationPassword = self.confirmPasswordTextField.text ? : @"";
+
+	// Validate that the new password and the old password are not the same.
+	if (oldPassword.length > 0 && [oldPassword isEqualToString:changedPassword]) {
+		[self showChangePasswordFailedAlertWithMessage:@"The old and the new password must not be the same"];
+		return;
+	}
+
+	// Validate that the new and confirmation passwords match.
+	if (NO == [changedPassword isEqualToString:confirmationPassword]) {
+		[self showChangePasswordFailedAlertWithMessage:@"The new passwords and the confirmation password must match"];
+		return;
+	}
+
+	/* 
+	 These are the three scenarios that are supported:
+	 1. A signle matching Login is found: 1Password will enter edit mode for that Login and will update its password using the value for AppExtensionPasswordKey.
+	 2. More than a one matching Logins are found: 1Password will display a list of all matching Logins. The user must choose which one to update. Once in edit mode, the Login will be updated with the new password.
+	 3. No matching login is found: 1Password will create a new Login using the optional fields if available to populate its properties.
+	*/
 	
 	NSDictionary *loginDetails = @{
 									  AppExtensionTitleKey: @"ACME", // Optional, used for the third schenario only
 									  AppExtensionUsernameKey: @"aUsername", // Optional, used for the third schenario only
-									  AppExtensionPasswordKey: newPassword,
+									  AppExtensionPasswordKey: changedPassword,
 									  AppExtensionOldPasswordKey: oldPassword,
 									  AppExtensionNotesKey: @"Saved with the ACME app", // Optional, used for the third schenario only
 									};
 
 	// The password generation options are optional, but are very handy in case you have strict rules about password lengths, symbols and digits.
 	NSDictionary *passwordGenerationOptions = @{
+												// The minimum password length can be 4 or more.
 												AppExtensionGeneratedPasswordMinLengthKey: @(8),
+
+												// The maximum password length can be 50 or less.
 												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
-												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
-												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
-												AppExtensionGeneratedPasswordForbiddenSymbolsKey: @"!@#$%/"
+
+												// If YES, the 1Password will guarantee that the generated password will contain at least one digit (number between 0 and 9). Passing NO will not exclude digits from the generated password.
+												AppExtensionGeneratedPasswordRequireDigitsKey: @(YES),
+
+												// If YES, the 1Password will guarantee that the generated password will contain at least one symbol (See the list bellow). Passing NO with will exclude symbols from the generated password.
+												AppExtensionGeneratedPasswordRequireSymbolsKey: @(YES),
+
+												// Here are all the symbols available in the the 1Password Password Generator:
+												// !@#$%^&*()_-+=|[]{}'\";.,>?/~`
+												// The string for AppExtensionGeneratedPasswordForbiddenCharactersKey should contain the symbols and characters that you wish 1Password to exclude from the generated password.
+
+												AppExtensionGeneratedPasswordForbiddenCharactersKey: @"!@#$%/0lIO"
 												};
 
 	[[OnePasswordExtension sharedExtension] changePasswordForLoginForURLString:@"https://www.acme.com" loginDetails:loginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Empowering your users to use strong, unique passwords has never been easier. Let
 
 ## Just Give Me the Code (TL;DR)
 
-You might be looking at this 19 KB README and think integrating with 1Password is very complicated. Nothing could be further from the truth!
+You might be looking at this 22 KB README and think integrating with 1Password is very complicated. Nothing could be further from the truth!
 
 If you're the type that just wants the code, here it is:
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Adding 1Password to your registration screen is very similar to adding 1Password
 												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
 												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
 												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
-												AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@"]
+												AppExtensionGeneratedPasswordForbiddenSymbolsKey: @"!@#$%/"												
 												};
 
 	[[OnePasswordExtension sharedExtension] storeLoginForURLString:@"https://www.acme.com" loginDetails:newLoginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {
@@ -198,7 +198,7 @@ Adding 1Password to your change password screen is very similar to adding 1Passw
 												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
 												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
 												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
-												AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@"]
+												AppExtensionGeneratedPasswordForbiddenSymbolsKey: @"!@#$%/"
 												};
 
 	[[OnePasswordExtension sharedExtension] changePasswordForLoginForURLString:@"https://www.acme.com" loginDetails:loginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {

--- a/README.md
+++ b/README.md
@@ -141,13 +141,16 @@ Adding 1Password to your registration screen is very similar to adding 1Password
 											  // Add as many string fields as you please.
 											  }
 									  };
-									  
-	// Password generation options are optional, but are very handy in case you have strict rules about password lengths
-		NSDictionary *passwordGenerationOptions = @{
-												AppExtensionGeneratedPasswordMinLengthKey: @(6), // The minimum value can be 4 or more
-												AppExtensionGeneratedPasswordMaxLengthKey: @(50) // The maximum value can be 50 or less
+
+	// The password generation options are optional, but are very handy in case you have strict rules about password lengths, symbols and digits.
+	NSDictionary *passwordGenerationOptions = @{
+												AppExtensionGeneratedPasswordMinLengthKey: @(8),
+												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
+												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
+												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
+												AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@"]
 												};
-												
+
 	[[OnePasswordExtension sharedExtension] storeLoginForURLString:@"https://www.acme.com" loginDetails:newLoginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {
 
 		if (loginDictionary.count == 0) {
@@ -178,22 +181,24 @@ Adding 1Password to your change password screen is very similar to adding 1Passw
 
 ```objective-c
 - (IBAction)changePasswordIn1Password:(id)sender {
-	NSString *changedPassword = self.freshPasswordTextField.text ? : @"";
+	NSString *newPassword = self.freshPasswordTextField.text ? : @"";
 	NSString *oldPassword = self.oldPasswordTextField.text ? : @"";
-	NSString *username = [LoginInformation sharedLoginInformation].username ? : @"";
-
+	
 	NSDictionary *loginDetails = @{
-									  AppExtensionTitleKey: @"ACME",
-									  AppExtensionUsernameKey: username, // 1Password will prompt the user to create a new item if no matching logins are found with this username.
-									  AppExtensionPasswordKey: changedPassword,
+									  AppExtensionTitleKey: @"ACME", // Optional, used for the third schenario only
+									  AppExtensionUsernameKey: @"aUsername", // Optional, used for the third schenario only
+									  AppExtensionPasswordKey: newPassword,
 									  AppExtensionOldPasswordKey: oldPassword,
-									  AppExtensionNotesKey: @"Saved with the ACME app",
+									  AppExtensionNotesKey: @"Saved with the ACME app", // Optional, used for the third schenario only
 									};
 
-	// Password generation options are optional, but are very handy in case you have strict rules about password lengths
-		NSDictionary *passwordGenerationOptions = @{
-												AppExtensionGeneratedPasswordMinLengthKey: @(6), // The minimum value can be 4 or more
-												AppExtensionGeneratedPasswordMaxLengthKey: @(50) // The maximum value can be 50 or less
+	// The password generation options are optional, but are very handy in case you have strict rules about password lengths, symbols and digits.
+	NSDictionary *passwordGenerationOptions = @{
+												AppExtensionGeneratedPasswordMinLengthKey: @(8),
+												AppExtensionGeneratedPasswordMaxLengthKey: @(30),
+												AppExtensionGeneratedPasswordUseDigitsKey: @(YES),
+												AppExtensionGeneratedPasswordUseSymbolsKey: @(YES),
+												AppExtensionGeneratedPasswordBlacklistedSymbolsKey: @[@"&", @"*", @"@"]
 												};
 
 	[[OnePasswordExtension sharedExtension] changePasswordForLoginForURLString:@"https://www.acme.com" loginDetails:loginDetails passwordGenerationOptions:passwordGenerationOptions forViewController:self sender:sender completion:^(NSDictionary *loginDictionary, NSError *error) {


### PR DESCRIPTION
These changes require 1Password for iOS 5.5 or later.

```
[NEW] Added the ability to blacklist unsupported characters when using the password generator options. {#36}

[IMPROVED] Improved the password generator options. {#36}

[FIXED] Fixed an issue where the Password Generator length keys were not honoured in 1Password 5.5. {#35}
```

This should resolve issues #35 and #36
