### PR TITLE
[Release] 1.5

### DIFF
--- a/1PasswordExtension.podspec
+++ b/1PasswordExtension.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
 
   s.name         = "1PasswordExtension"
   s.header_dir   = "OnePasswordExtension"
-  s.version      = "1.2"
+  s.version      = "1.5"
   s.summary      = "With just a few lines of code, your app can add 1Password support."
 
   s.description  = <<-DESC

--- a/Demos/App Demo for iOS/App Demo for iOS/Info.plist
+++ b/Demos/App Demo for iOS/App Demo for iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2</string>
+	<string>1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Demos/WebView Demo for iOS/WebView Demo for iOS/Info.plist
+++ b/Demos/WebView Demo for iOS/WebView Demo for iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2</string>
+	<string>1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/OnePasswordExtension.h
+++ b/OnePasswordExtension.h
@@ -200,10 +200,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)fillReturnedItems:(nullable NSArray *)returnedItems intoWebView:(nonnull id)webView completion:(nullable void (^)(BOOL success, NSError * __nullable error))completion;
 
 /*!
- Deprecated in version 1.3.
+ Deprecated in version 1.5
  @see Use fillItemIntoWebView:forViewController:sender:showOnlyLogins:completion: instead
  */
-- (void)fillLoginIntoWebView:(nonnull id)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender completion:(nullable void (^)(BOOL success, NSError * __nullable error))completion __attribute__((deprecated("Use fillItemIntoWebView:forViewController:sender:showOnlyLogins:completion: instead. Deprecated in version 1.3")));
+- (void)fillLoginIntoWebView:(nonnull id)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender completion:(nullable void (^)(BOOL success, NSError * __nullable error))completion __attribute__((deprecated("Use fillItemIntoWebView:forViewController:sender:showOnlyLogins:completion: instead. Deprecated in version 1.5")));
 @end
 
 #if __has_feature(nullability)

--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -8,7 +8,7 @@
 #import "OnePasswordExtension.h"
 
 // Version
-#define VERSION_NUMBER @(120)
+#define VERSION_NUMBER @(150)
 static NSString *const AppExtensionVersionNumberKey = @"version_number";
 
 // Available App Extension Actions

--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -669,7 +669,7 @@ function w(a){var b;if(void 0===a||null===a)return null;try{var c=Array.prototyp
 #pragma mark - Deprecated methods
 
 /*
- Deprecated in version 1.3.
+ Deprecated in version 1.5
  Use fillItemIntoWebView:forViewController:sender:showOnlyLogins:completion: instead
  */
 - (void)fillLoginIntoWebView:(nonnull id)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender completion:(nullable void (^)(BOOL success, NSError * __nullable error))completion {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To get started, download the [zip version](https://github.com/AgileBits/onepassw
 
 Inside the downloaded folder, you'll find the resources needed to integrate with 1Password, such as images and sample code. The sample code includes two apps from ACME Corporation: one that demonstrates how to integrate the 1Password Login and Registration features, as well as a web browser that showcases the web view Filling feature.
 
-The 1Password App Extension API is also available via CocoaPods, simply add `pod '1PasswordExtension', '~> 1.2'` (for the latest stable release) or `pod '1PasswordExtension', :git => 'https://github.com/AgileBits/onepassword-app-extension.git', :branch => 'master'` (for the latest nightly) to your Podfile, run `pod install` from your project directory and you're ready to go.
+The 1Password App Extension API is also available via CocoaPods, simply add `pod '1PasswordExtension', '~> 1.5'` (for the latest stable release) or `pod '1PasswordExtension', :git => 'https://github.com/AgileBits/onepassword-app-extension.git', :branch => 'master'` (for the latest nightly) to your Podfile, run `pod install` from your project directory and you're ready to go.
 
 The 1Password App Extension API is available via Carthage as well. Simply add `github AgileBits/onepassword-extension "add-framework-support"` to your Cartfile, then run `carthage boostrap` and add it to your project.
 


### PR DESCRIPTION
[NEW] Added the ability to retrieve the generated One-Time Password from the 1Password Login if available. {#163, #199}
[NEW] Added the ability to specify unsupported  characters when using the password generator options. {#36}
[NEW] Added nullability for improved compatibility with Swift projects. {#218, #241,#245}
[NEW] Our demo apps, **ACME** and **ACME Browser** are now written in [Swift 1.2](https://github.com/AgileBits/onepassword-app-extension/tree/new/swift-demo-apps) and [Swift 2.0](https://github.com/AgileBits/onepassword-app-extension/tree/swift2.0) too. {#101}
[NEW] Added ability to use the WKWebView code when the Deployment Target is iOS 7.1 or earlier. {#214}

[IMPROVED] Simplified [Web View Filling](https://github.com/AgileBits/onepassword-app-extension#use-case-4-web-view-filling). {#200}
[IMPROVED] Fully compatible with iOS 9 and Xcode 7. {#238, #241}
[IMPROVED] Improved compatibility with the latest version of CocoaPods. {#187, #235}
[IMPROVED] Improved the README, the in-code documentation and spring cleaned the entire codebase. {#200, #202, #203, #206, 241}
[IMPROVED] Improved the password generator options. {#36}
[IMPROVED] Updated the collect and fill scripts for the latest 1Password Brain. {#193}
[IMPROVED] We now assert when the `sender` parameter is `nil` on iPad. {#226, #241}
[IMPROVED] Improved Google Search in ACME Browser. {#240}
[IMPROVED] ACME Browser is now a Universal app. {#242}

[FIXED] Fixed all xcassets warnings {#196}
[FIXED] Fixed an issue where the Password Generator length keys were not honoured in 1Password 5.5. {#35}
[FIXED] Fixed typo for the `AppExtensionPasswordGeneratorOptionsKey` constant. {#191}
