### PR TITLE
[FIXED] Forcing the Swift demo apps to portrait mode.

### DIFF
--- a/Demos/App Demo for iOS Swift/App Demo for iOS Swift/Info.plist
+++ b/Demos/App Demo for iOS Swift/App Demo for iOS Swift/Info.plist
@@ -42,8 +42,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/Demos/WebView Demo for iOS Swift/WebView Demo for iOS Swift/Info.plist
+++ b/Demos/WebView Demo for iOS Swift/WebView Demo for iOS Swift/Info.plist
@@ -52,8 +52,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>


### PR DESCRIPTION
Forcing the Swift demo apps to portrait mode to match the Objective-C demo apps.