### PR TITLE
fix issue with cocoa pods 0.39 and static library.

### DIFF
--- a/1PasswordExtension.podspec
+++ b/1PasswordExtension.podspec
@@ -3,6 +3,7 @@ Pod::Spec.new do |s|
 
   s.name         = "1PasswordExtension"
   s.header_dir   = "OnePasswordExtension"
+  s.header_mappings_dir = "OnePasswordExtension"
   s.version      = "1.6.2"
   s.summary      = "With just a few lines of code, your app can add 1Password support."
 


### PR DESCRIPTION
if we don’t use « use_frameworks! » in the podfile, we can’t build the
project anymore (impossible to find header file).