### PR TITLE
Change typeIdentifier used in createExtensionItemForURLString

### DIFF
--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -547,7 +547,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 
 	NSDictionary *item = @{ AppExtensionVersionNumberKey : VERSION_NUMBER, AppExtensionURLStringKey : URLString, AppExtensionWebViewPageDetails : webPageDetailsDictionary };
 
-	NSItemProvider *itemProvider = [[NSItemProvider alloc] initWithItem:item typeIdentifier:kUTTypeAppExtensionFillBrowserAction];
+	NSItemProvider *itemProvider = [[NSItemProvider alloc] initWithItem:item typeIdentifier:kUTTypeAppExtensionFillWebViewAction];
 
 	NSExtensionItem *extensionItem = [[NSExtensionItem alloc] init];
 	extensionItem.attachments = @[ itemProvider ];


### PR DESCRIPTION
…in order to maintain compat with LastPass.

 * I am filling from a WKWebView in a browser.
 * LastPass does not support kUTTypeAppExtensionFillBrowserAction very well.
 * GenericPasswordExtension does not support kUTTypeAppExtensionFillBrowserAction at all.

There's a wider conversation to be had re: supporting LastPass for other codepaths.

Relevant: 
 * https://github.com/mozilla/firefox-ios/pull/510
 * https://github.com/mozilla/firefox-ios/pull/1191