### PR TITLE
Enabling documentation warnings, and fixing HeaderDoc invalid documentation

### DIFF
--- a/Demos/App Demo for iOS/App Demo for iOS.xcodeproj/project.pbxproj
+++ b/Demos/App Demo for iOS/App Demo for iOS.xcodeproj/project.pbxproj
@@ -276,7 +276,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "acme-anvil-corp";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/App Demo for iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.agilebits.${PRODUCT_NAME:rfc1034identifier}";
@@ -290,7 +289,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "acme-anvil-corp";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/App Demo for iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.agilebits.${PRODUCT_NAME:rfc1034identifier}";

--- a/Demos/App Demo for iOS/App Demo for iOS.xcodeproj/project.pbxproj
+++ b/Demos/App Demo for iOS/App Demo for iOS.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "acme-anvil-corp";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/App Demo for iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.agilebits.${PRODUCT_NAME:rfc1034identifier}";
@@ -289,6 +290,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "acme-anvil-corp";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/App Demo for iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.agilebits.${PRODUCT_NAME:rfc1034identifier}";

--- a/OnePasswordExtension.h
+++ b/OnePasswordExtension.h
@@ -92,9 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param sender The sender which triggers the share sheet to show. UIButton, UIBarButtonItem or UIView. Can also be nil on iPhone, but not on iPad.
  
- @param LoginDictionary Reply parameter that contains the username, password and the One-Time Password if available.
- 
- @param error Reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
+ @param completion A completion block called with two parameters loginDictionary and error once completed. The loginDictionary reply parameter that contains the username, password and the One-Time Password if available. The error Reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
  */
 - (void)findLoginForURLString:(nonnull NSString *)URLString forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender completion:(nullable void (^)(NSDictionary * __nullable loginDictionary, NSError * __nullable error))completion;
 
@@ -115,9 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param sender The sender which triggers the share sheet to show. UIButton, UIBarButtonItem or UIView. Can also be nil on iPhone, but not on iPad.
  
- @param LoginDictionary Reply parameter which contain all the information about the newly saved Login. Use the `Login Dictionary keys` above to extract the needed information and update your UI. For example, updating the UI with the newly generated password lets the user know their action was successful.
- 
- @param error Reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
+ @param completion A completion block which is called with type parameters loginDictionary and error. The loginDictionary peply parameter which contain all the information about the newly saved Login. Use the `Login Dictionary keys` above to extract the needed information and update your UI. For example, updating the UI with the newly generated password lets the user know their action was successful. The error reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
  */
 - (void)storeLoginForURLString:(nonnull NSString *)URLString loginDetails:(nullable NSDictionary *)loginDetailsDictionary passwordGenerationOptions:(nullable NSDictionary *)passwordGenerationOptions forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender completion:(nullable void (^)(NSDictionary * __nullable loginDictionary, NSError * __nullable error))completion;
 
@@ -145,9 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param sender The sender which triggers the share sheet to show. UIButton, UIBarButtonItem or UIView. Can also be nil on iPhone, but not on iPad.
  
- @param LoginDictionary Reply parameter which contain all the information about the newly updated Login, including the newly generated and the old password. Use the `Login Dictionary keys` above to extract the needed information and update your UI. For example, updating the UI with the newly generated password lets the user know their action was successful.
- 
- @param error Reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
+ @param completion A completion block which is called with type parameters loginDictionary and error. The loginDictionary reply parameter which contain all the information about the newly updated Login, including the newly generated and the old password. Use the `Login Dictionary keys` above to extract the needed information and update your UI. For example, updating the UI with the newly generated password lets the user know their action was successful. The error reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
  */
 - (void)changePasswordForLoginForURLString:(nonnull NSString *)URLString loginDetails:(nullable NSDictionary *)loginDetailsDictionary passwordGenerationOptions:(nullable NSDictionary *)passwordGenerationOptions forViewController:(UIViewController *)viewController sender:(nullable id)sender completion:(nullable void (^)(NSDictionary * __nullable loginDictionary, NSError * __nullable error))completion;
 
@@ -167,9 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param yesOrNo Boolean flag. If YES is passed only matching Login items will be shown, otherwise the 1Password Extension will also display Credit Cards and Identities.
  
- @param success Reply parameter that is YES if the 1Password Extension has been successfully completed or NO otherwise.
- 
- @param error Reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
+ @param completion Completion block called on completion with parameters success, and error. The success reply parameter that is YES if the 1Password Extension has been successfully completed or NO otherwise. The error reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
  */
 - (void)fillItemIntoWebView:(nonnull id)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender showOnlyLogins:(BOOL)yesOrNo completion:(nullable void (^)(BOOL success, NSError * __nullable error))completion;
 
@@ -187,9 +179,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param webView The web view which displays the form to be filled. The active UIWebView Or WKWebView. Must not be nil.
  
- @param extensionItem Reply parameter that is contains all the info required by the 1Password extension if has been successfully completed or nil otherwise.
- 
- @param error Reply parameter that is nil if the 1Password extension item has been successfully created, or it contains error information about the completion failure.
+ @param completion Completion block called on completion with extensionItem and error. The extensionItem reply parameter that is contains all the info required by the 1Password extension if has been successfully completed or nil otherwise. The error reply parameter that is nil if the 1Password extension item has been successfully created, or it contains error information about the completion failure.
  */
 - (void)createExtensionItemForWebView:(nonnull id)webView completion:(void (^)(NSExtensionItem * __nullable extensionItem, NSError * __nullable error))completion;
 
@@ -199,9 +189,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param returnedItems Array which contains the selected activity in the share sheet. Empty array if the share sheet is cancelled by the user.
  @param webView The web view which displays the form to be filled. The active UIWebView Or WKWebView. Must not be nil.
  
- @param success Reply parameter that is YES if the 1Password Extension has been successfully completed or NO otherwise.
- 
- @param error Reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
+ @param completion Completion block called on completion with parameters success, and error. The success reply parameter that is YES if the 1Password Extension has been successfully completed or NO otherwise. The error reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
  */
 - (void)fillReturnedItems:(nullable NSArray *)returnedItems intoWebView:(nonnull id)webView completion:(nullable void (^)(BOOL success, NSError * __nullable error))completion;
 


### PR DESCRIPTION
The extension triggers warnings when compiled with CLANG_WARN_DOCUMENTATION_COMMENTS=true.

This PR fixes the warnings and enables this warning by default (to help avoid this issue in future).
