### PR TITLE
Support application activities in findLogin method

### DIFF
--- a/OnePasswordExtension.h
+++ b/OnePasswordExtension.h
@@ -97,6 +97,28 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)findLoginForURLString:(nonnull NSString *)URLString forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender completion:(nullable void (^)(NSDictionary * __nullable loginDictionary, NSError * __nullable error))completion;
 
 /*!
+ Called from your login page, this method will find all available logins for the given URLString, allowing you to pass in application activities to be includes in the UIActivityViewController.
+ 
+ @discussion 1Password will show all matching Login for the naked domain of the given URLString. For example if the user has an item in your 1Password vault with "subdomain1.domain.com” as the website and another one with "subdomain2.domain.com”, and the URLString is "https://domain.com", 1Password will show both items.
+ 
+ However, if no matching login is found for "https://domain.com", the 1Password Extension will display the "Show all Logins" button so that the user can search among all the Logins in the vault. This is especially useful when the user has a login for "https://olddomain.com".
+ 
+ After the user selects a login, it is stored into an NSDictionary and given to your completion handler. Use the `Login Dictionary keys` above to
+ extract the needed information and update your UI. The completion block is guaranteed to be called on the main thread.
+ 
+ @param URLString For the matching Logins in the 1Password vault.
+ 
+ @param viewController The view controller from which the 1Password Extension is invoked. Usually `self`
+ 
+ @param sender The sender which triggers the share sheet to show. UIButton, UIBarButtonItem or UIView. Can also be nil on iPhone, but not on iPad.
+ 
+ @param applicationActivities Any custom UIActivity objects defined by the application that should be displayed in the UIActivityViewController that will be presented.
+ 
+ @param completion A completion block called with two parameters loginDictionary and error once completed. The loginDictionary reply parameter that contains the username, password and the One-Time Password if available. The error Reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
+ */
+- (void)findLoginForURLString:(nonnull NSString *)URLString forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender applicationActivities:(nullable NSArray<UIActivity *> *)applicationActivities completion:(nullable void (^)(NSDictionary * __nullable loginDictionary, NSError * __nullable error))completion;
+
+/*!
  Create a new login within 1Password and allow the user to generate a new password before saving.
  
  @discussion The provided URLString should be unique to your app or service and be identical to what you pass into the find login method.

--- a/OnePasswordExtension.m
+++ b/OnePasswordExtension.m
@@ -48,6 +48,10 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 #pragma mark - Native app Login
 
 - (void)findLoginForURLString:(nonnull NSString *)URLString forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender completion:(nullable void (^)(NSDictionary * __nullable loginDictionary, NSError * __nullable error))completion {
+    [self findLoginForURLString:URLString forViewController:viewController sender:sender applicationActivities:nil completion:completion];
+}
+
+- (void)findLoginForURLString:(nonnull NSString *)URLString forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender applicationActivities:(nullable NSArray<UIActivity *> *)applicationActivities completion:(nullable void (^)(NSDictionary * __nullable loginDictionary, NSError * __nullable error))completion {
 	NSAssert(URLString != nil, @"URLString must not be nil");
 	NSAssert(viewController != nil, @"viewController must not be nil");
 
@@ -63,7 +67,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 #ifdef __IPHONE_8_0
 	NSDictionary *item = @{ AppExtensionVersionNumberKey: VERSION_NUMBER, AppExtensionURLStringKey: URLString };
 
-	UIActivityViewController *activityViewController = [self activityViewControllerForItem:item viewController:viewController sender:sender typeIdentifier:kUTTypeAppExtensionFindLoginAction];
+	UIActivityViewController *activityViewController = [self activityViewControllerForItem:item applicationActivities:applicationActivities viewController:viewController sender:sender typeIdentifier:kUTTypeAppExtensionFindLoginAction];
 	activityViewController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
 		if (returnedItems.count == 0) {
 			NSError *error = nil;
@@ -118,7 +122,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 		newLoginAttributesDict[AppExtensionPasswordGeneratorOptionsKey] = passwordGenerationOptions;
 	}
 
-	UIActivityViewController *activityViewController = [self activityViewControllerForItem:newLoginAttributesDict viewController:viewController sender:sender typeIdentifier:kUTTypeAppExtensionSaveLoginAction];
+	UIActivityViewController *activityViewController = [self activityViewControllerForItem:newLoginAttributesDict applicationActivities:nil viewController:viewController sender:sender typeIdentifier:kUTTypeAppExtensionSaveLoginAction];
 	activityViewController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
 		if (returnedItems.count == 0) {
 			NSError *error = nil;
@@ -172,7 +176,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 		item[AppExtensionPasswordGeneratorOptionsKey] = passwordGenerationOptions;
 	}
 
-	UIActivityViewController *activityViewController = [self activityViewControllerForItem:item viewController:viewController sender:sender typeIdentifier:kUTTypeAppExtensionChangePasswordAction];
+	UIActivityViewController *activityViewController = [self activityViewControllerForItem:item applicationActivities:nil viewController:viewController sender:sender typeIdentifier:kUTTypeAppExtensionChangePasswordAction];
 
 	activityViewController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
 		if (returnedItems.count == 0) {
@@ -340,7 +344,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 	NSDictionary *item = @{ AppExtensionVersionNumberKey : VERSION_NUMBER, AppExtensionURLStringKey : URLString, AppExtensionWebViewPageDetails : collectedPageDetailsDictionary };
 
 	NSString *typeIdentifier = yesOrNo ? kUTTypeAppExtensionFillWebViewAction  : kUTTypeAppExtensionFillBrowserAction;
-	UIActivityViewController *activityViewController = [self activityViewControllerForItem:item viewController:forViewController sender:sender typeIdentifier:typeIdentifier];
+	UIActivityViewController *activityViewController = [self activityViewControllerForItem:item applicationActivities:nil viewController:forViewController sender:sender typeIdentifier:typeIdentifier];
 	activityViewController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
 		if (returnedItems.count == 0) {
 			NSError *error = nil;
@@ -502,7 +506,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 	 }];
 }
 
-- (UIActivityViewController *)activityViewControllerForItem:(nonnull NSDictionary *)item viewController:(nonnull UIViewController*)viewController sender:(nullable id)sender typeIdentifier:(nonnull NSString *)typeIdentifier {
+- (UIActivityViewController *)activityViewControllerForItem:(nonnull NSDictionary *)item applicationActivities:(nullable NSArray<UIActivity *> *)applicationActivities viewController:(nonnull UIViewController*)viewController sender:(nullable id)sender typeIdentifier:(nonnull NSString *)typeIdentifier {
 #ifdef __IPHONE_8_0
 	NSAssert(NO == (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad && sender == nil), @"sender must not be nil on iPad.");
 
@@ -511,7 +515,7 @@ static NSString *const AppExtensionWebViewPageDetails = @"pageDetails";
 	NSExtensionItem *extensionItem = [[NSExtensionItem alloc] init];
 	extensionItem.attachments = @[ itemProvider ];
 
-	UIActivityViewController *controller = [[UIActivityViewController alloc] initWithActivityItems:@[ extensionItem ]  applicationActivities:nil];
+	UIActivityViewController *controller = [[UIActivityViewController alloc] initWithActivityItems:@[ extensionItem ]  applicationActivities:applicationActivities];
 
 	if ([sender isKindOfClass:[UIBarButtonItem class]]) {
 		controller.popoverPresentationController.barButtonItem = sender;


### PR DESCRIPTION
This proposal solves a need that was discussed in #109. In our app, we want to present custom options for signing in from the `UIActivityViewController`. The API support from Apple is straightforward—just provide application activities as `UIActivity` objects when creating the activity view controller.

This would be a non-breaking change that would add an additional method that could be called if it is desirable to pass in application activities.

We are using Carthage to pull in the extension, so we are working from the `add-framework-support`, and I'm hoping this will be approved and easily merged into that branch as well. Thanks!