### PR TITLE
[FIXED] Fixed a crash caused by unwrapping an Optional value while running ACME Swift on iPad.

### DIFF
--- a/Demos/App Demo for iOS Swift/App Demo for iOS Swift/ChangePasswordViewController.swift
+++ b/Demos/App Demo for iOS Swift/App Demo for iOS Swift/ChangePasswordViewController.swift
@@ -16,7 +16,11 @@ class ChangePasswordViewController: UIViewController {
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		self.view.backgroundColor = UIColor(patternImage: UIImage(named: "login-background.png")!)
+
+		if let patternImage = UIImage(named: "login-background.png") {
+			self.view.backgroundColor = UIColor(patternImage: patternImage)
+		}
+		
 		self.onepasswordButton.hidden = (false == OnePasswordExtension.sharedExtension().isAppExtensionAvailable())
 	}
 	

--- a/Demos/App Demo for iOS Swift/App Demo for iOS Swift/LoginViewController.swift
+++ b/Demos/App Demo for iOS Swift/App Demo for iOS Swift/LoginViewController.swift
@@ -17,7 +17,11 @@ class LoginViewController: UIViewController {
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		self.view.backgroundColor = UIColor(patternImage: UIImage(named: "login-background.png")!)
+		
+		if let patternImage = UIImage(named: "login-background.png") {
+			self.view.backgroundColor = UIColor(patternImage: patternImage)
+		}
+		
 		self.onepasswordButton.hidden = (false == OnePasswordExtension.sharedExtension().isAppExtensionAvailable())
 	}
 

--- a/Demos/App Demo for iOS Swift/App Demo for iOS Swift/RegisterViewController.swift
+++ b/Demos/App Demo for iOS Swift/App Demo for iOS Swift/RegisterViewController.swift
@@ -17,7 +17,11 @@ class RegisterViewController: UIViewController {
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		self.view.backgroundColor = UIColor(patternImage: UIImage(named: "register-background.png")!)
+		
+		if let patternImage = UIImage(named: "register-background.png") {
+			self.view.backgroundColor = UIColor(patternImage: patternImage)
+		}
+		
 		self.onepasswordButton.hidden = (false == OnePasswordExtension.sharedExtension().isAppExtensionAvailable())
 	}
 

--- a/Demos/App Demo for iOS Swift/App Demo for iOS Swift/ThankYouViewController.swift
+++ b/Demos/App Demo for iOS Swift/App Demo for iOS Swift/ThankYouViewController.swift
@@ -11,7 +11,11 @@ import Foundation
 class ThankYouViewController: UIViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		self.view.backgroundColor = UIColor(patternImage: UIImage(named: "login-background.png")!)
+		
+		if let patternImage = UIImage(named: "login-background.png") {
+			self.view.backgroundColor = UIColor(patternImage: patternImage)
+		}
+
 	}
 	
 	override func preferredStatusBarStyle() -> UIStatusBarStyle {


### PR DESCRIPTION
### Steps to reproduce

Launch ACME Swift (`App Demo for iOS Swift`) on an iPad.

#### Expected

The app should simply run, even if no images are available in `Images.xcassets`. This should and will be addressed separately

#### Actual

Bam! It crashes on launch with the `"fatal error: unexpectedly found nil while unwrapping an Optional value"` error message in the console.