### PR TITLE
Fix warning: MobileCoreServices has been renamed. Use CoreServices instead.

### DIFF
--- a/1PasswordExtension.podspec
+++ b/1PasswordExtension.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |spec|
   spec.source           = { :git => "https://github.com/AgileBits/onepassword-app-extension.git", :tag => spec.version }
   spec.platform         = :ios, 9.0
   spec.source_files     = "*.{h,m}"
-  spec.frameworks       = [ 'Foundation', 'MobileCoreServices', 'UIKit' ]
+  spec.frameworks       = [ 'Foundation', 'UIKit' ]
   spec.weak_framework   = "WebKit"
   spec.exclude_files    = "Demos"
   spec.resource_bundles = { 'OnePasswordExtensionResources' => ['1Password.xcassets/*.imageset/*.png', '1Password.xcassets'] }


### PR DESCRIPTION
Close #420

If our library was installed via CocoaPods, Xcode 11.4 will issue the warning "MobileCoreServices has been renamed. Use CoreServices instead.".

![image](https://user-images.githubusercontent.com/526008/77892980-eecffd80-72a5-11ea-891b-78acd78d4b7c.png)

How to fix: Do not explicitly link `MobileCoreServices.framework` in the CocoaPods generated project, by deleting `MobileCoreServices` from the `spec.frameworks` attribute in our podspec file.

More info: https://github.com/AFNetworking/AFNetworking/pull/4532
